### PR TITLE
ValidationProblemExtensions Fixes

### DIFF
--- a/Atc.Rest.MinimalApi.sln
+++ b/Atc.Rest.MinimalApi.sln
@@ -12,6 +12,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{DAC1423F-D
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Atc.Rest.MinimalApi", "src\Atc.Rest.MinimalApi\Atc.Rest.MinimalApi.csproj", "{48083BEB-5AB3-432F-B2E5-059D3FB4E620}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{58BC6728-197C-484C-A8EC-38BC2F0B58C4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Atc.Rest.MinimalApi.Tests", "test\Atc.Rest.MinimalApi.Tests\Atc.Rest.MinimalApi.Tests.csproj", "{7280EDF9-17CB-478F-BE69-4906C84E04D5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -22,12 +26,17 @@ Global
 		{48083BEB-5AB3-432F-B2E5-059D3FB4E620}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{48083BEB-5AB3-432F-B2E5-059D3FB4E620}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{48083BEB-5AB3-432F-B2E5-059D3FB4E620}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7280EDF9-17CB-478F-BE69-4906C84E04D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7280EDF9-17CB-478F-BE69-4906C84E04D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7280EDF9-17CB-478F-BE69-4906C84E04D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7280EDF9-17CB-478F-BE69-4906C84E04D5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{48083BEB-5AB3-432F-B2E5-059D3FB4E620} = {69C84246-AA75-43E8-94B2-66FD555B18B0}
+		{7280EDF9-17CB-478F-BE69-4906C84E04D5} = {58BC6728-197C-484C-A8EC-38BC2F0B58C4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {04120463-05C5-417B-8D7A-2D7D35B71A07}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,6 +38,10 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  
+    <PropertyGroup>
+    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+  </PropertyGroup>
 
   <!-- Shared code analyzers used for all projects in the solution -->
   <ItemGroup Label="Code Analyzers">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,10 +43,10 @@
   <ItemGroup Label="Code Analyzers">
     <PackageReference Include="AsyncFixer" Version="1.6.0" PrivateAssets="All" />
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="1.0.757" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.80" PrivateAssets="All" />
     <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.55.0.65544" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.6.0.74858" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Atc.Rest.MinimalApi/Assembly.cs.cs
+++ b/src/Atc.Rest.MinimalApi/Assembly.cs.cs
@@ -1,0 +1,1 @@
+[assembly: InternalsVisibleTo("Atc.Rest.MinimalApi.Tests")]

--- a/src/Atc.Rest.MinimalApi/Atc.Rest.MinimalApi.csproj
+++ b/src/Atc.Rest.MinimalApi/Atc.Rest.MinimalApi.csproj
@@ -14,10 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="7.0.0" />
-    <PackageReference Include="Atc" Version="2.0.251" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
-    <PackageReference Include="MiniValidation" Version="0.7.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
+    <PackageReference Include="Atc" Version="2.0.349" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="MiniValidation" Version="0.8.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atc.Rest.MinimalApi/Extensions/DictionaryExtensions.cs
+++ b/src/Atc.Rest.MinimalApi/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,28 @@
+namespace Atc.Rest.MinimalApi.Extensions;
+
+internal static class DictionaryExtensions
+{
+    internal static IDictionary<string, string[]> MergeErrors(
+        this IDictionary<string, string[]> errorsA,
+        IDictionary<string, string[]> errorsB)
+    {
+        var result = new Dictionary<string, string[]>(StringComparer.Ordinal);
+
+        if (!errorsA.Any() &&
+            !errorsB.Any())
+        {
+            return result;
+        }
+
+        return errorsA
+            .Concat(errorsB)
+            .GroupBy(x => x.Key, StringComparer.Ordinal)
+            .ToDictionary(
+                x => x.Key,
+                x => x
+                    .SelectMany(y => y.Value)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray(),
+                StringComparer.Ordinal);
+    }
+}

--- a/src/Atc.Rest.MinimalApi/Extensions/DictionaryExtensions.cs
+++ b/src/Atc.Rest.MinimalApi/Extensions/DictionaryExtensions.cs
@@ -7,8 +7,10 @@ internal static class DictionaryExtensions
     /// </summary>
     /// <param name="errorsA">The first dictionary of errors to merge.</param>
     /// <param name="errorsB">The second dictionary of errors to merge.</param>
-    /// <returns>A new dictionary which includes the keys and values from both input dictionaries.
-    /// If the same key exists in both dictionaries, the values are merged and duplicates are removed.</returns>
+    /// <returns>
+    /// A new dictionary which includes the keys and values from both <paramref name="errorsA"/> and <paramref name="errorsB"/>.
+    /// If the same key exists in both dictionaries, the values are merged and duplicates are removed.
+    /// </returns>
     internal static IDictionary<string, string[]> MergeErrors(
         this IDictionary<string, string[]> errorsA,
         IDictionary<string, string[]> errorsB)

--- a/src/Atc.Rest.MinimalApi/Extensions/DictionaryExtensions.cs
+++ b/src/Atc.Rest.MinimalApi/Extensions/DictionaryExtensions.cs
@@ -2,6 +2,13 @@ namespace Atc.Rest.MinimalApi.Extensions;
 
 internal static class DictionaryExtensions
 {
+    /// <summary>
+    /// Merges two dictionaries containing errors and ensures there are no duplicate values for the same key.
+    /// </summary>
+    /// <param name="errorsA">The first dictionary of errors to merge.</param>
+    /// <param name="errorsB">The second dictionary of errors to merge.</param>
+    /// <returns>A new dictionary which includes the keys and values from both input dictionaries.
+    /// If the same key exists in both dictionaries, the values are merged and duplicates are removed.</returns>
     internal static IDictionary<string, string[]> MergeErrors(
         this IDictionary<string, string[]> errorsA,
         IDictionary<string, string[]> errorsB)

--- a/src/Atc.Rest.MinimalApi/Extensions/DictionaryExtensions.cs
+++ b/src/Atc.Rest.MinimalApi/Extensions/DictionaryExtensions.cs
@@ -15,8 +15,8 @@ internal static class DictionaryExtensions
     {
         var result = new Dictionary<string, string[]>(StringComparer.Ordinal);
 
-        if (!errorsA.Any() &&
-            !errorsB.Any())
+        if (errorsA.Count == 0 &&
+            errorsB.Count == 0)
         {
             return result;
         }

--- a/src/Atc.Rest.MinimalApi/Extensions/DictionaryExtensions.cs
+++ b/src/Atc.Rest.MinimalApi/Extensions/DictionaryExtensions.cs
@@ -13,12 +13,10 @@ internal static class DictionaryExtensions
         this IDictionary<string, string[]> errorsA,
         IDictionary<string, string[]> errorsB)
     {
-        var result = new Dictionary<string, string[]>(StringComparer.Ordinal);
-
         if (errorsA.Count == 0 &&
             errorsB.Count == 0)
         {
-            return result;
+            return new Dictionary<string, string[]>(StringComparer.Ordinal);
         }
 
         return errorsA

--- a/src/Atc.Rest.MinimalApi/Extensions/ValidationProblemExtensions.cs
+++ b/src/Atc.Rest.MinimalApi/Extensions/ValidationProblemExtensions.cs
@@ -77,6 +77,7 @@ public static class ValidationProblemExtensions
             if (propertyInfo is null)
             {
                 depth = depth.Skip(1).ToArray();
+                newKey.Append(propertyName);
                 continue;
             }
 

--- a/src/Atc.Rest.MinimalApi/Extensions/ValidationProblemExtensions.cs
+++ b/src/Atc.Rest.MinimalApi/Extensions/ValidationProblemExtensions.cs
@@ -63,7 +63,7 @@ public static class ValidationProblemExtensions
                 .FirstOrDefault() as JsonPropertyNameAttribute;
 
             depth = depth.Skip(1).ToArray();
-            name = jsonPropertyNameAttribute?.Name;
+            name = jsonPropertyNameAttribute?.Name ?? propertyName;
             newKey.Append(name);
 
             if (errorName.Contains('[', StringComparison.Ordinal) &&

--- a/src/Atc.Rest.MinimalApi/Extensions/ValidationProblemExtensions.cs
+++ b/src/Atc.Rest.MinimalApi/Extensions/ValidationProblemExtensions.cs
@@ -1,14 +1,29 @@
 // ReSharper disable ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
 namespace Atc.Rest.MinimalApi.Extensions;
 
+/// <summary>
+/// Provides extension methods for handling validation problems and managing serialization types.
+/// </summary>
 public static class ValidationProblemExtensions
 {
+    /// <summary>
+    /// Resolves the serialization type names in the provided validation problem.
+    /// </summary>
+    /// <param name="validationProblem">The validation problem whose serialization type names need to be resolved.</param>
+    /// <typeparam name="T">The type of the object being validated.</typeparam>
+    /// <returns>A validation problem with resolved serialization type names.</returns>
     public static ValidationProblem ResolveSerializationTypeNames<T>(
         this ValidationProblem validationProblem)
         where T : class
         => ResolveSerializationTypeNames<T>(
             validationProblem.ProblemDetails.Errors);
 
+    /// <summary>
+    /// Resolves the serialization type names in the provided dictionary of errors.
+    /// </summary>
+    /// <param name="errors">The dictionary of errors whose serialization type names need to be resolved.</param>
+    /// <typeparam name="T">The type of the object being validated.</typeparam>
+    /// <returns>A validation problem with resolved serialization type names.</returns>
     public static ValidationProblem ResolveSerializationTypeNames<T>(
         this IDictionary<string, string[]> errors)
         where T : class

--- a/src/Atc.Rest.MinimalApi/Extensions/ValidationProblemExtensions.cs
+++ b/src/Atc.Rest.MinimalApi/Extensions/ValidationProblemExtensions.cs
@@ -5,7 +5,8 @@ public static class ValidationProblemExtensions
     public static ValidationProblem ResolveSerializationTypeNames<T>(
         this ValidationProblem validationProblem)
         where T : class
-        => ResolveSerializationTypeNames<T>(validationProblem.ProblemDetails.Errors);
+        => ResolveSerializationTypeNames<T>(
+            validationProblem.ProblemDetails.Errors);
 
     public static ValidationProblem ResolveSerializationTypeNames<T>(
         this IDictionary<string, string[]> errors)

--- a/src/Atc.Rest.MinimalApi/Extensions/ValidationProblemExtensions.cs
+++ b/src/Atc.Rest.MinimalApi/Extensions/ValidationProblemExtensions.cs
@@ -1,3 +1,4 @@
+// ReSharper disable ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
 namespace Atc.Rest.MinimalApi.Extensions;
 
 public static class ValidationProblemExtensions
@@ -29,7 +30,11 @@ public static class ValidationProblemExtensions
 
                 var newKey = jsonPropertyNameAttribute?.Name ?? key;
                 newErrors.Add(newKey, values);
-                ResolveSerializationTypeName(values, key, newKey);
+
+                if (key != newKey)
+                {
+                    ReplaceSerializationTypeName(values, key, newKey);
+                }
             }
         }
 
@@ -88,9 +93,11 @@ public static class ValidationProblemExtensions
 
         newErrors.Add(newKey.ToString(), values);
 
-        if (name != null)
+        var splitKey = key.Split('.');
+        if (name is not null &&
+            splitKey.Length > 0 && name != splitKey[^1])
         {
-            ResolveSerializationTypeName(values, key.Split('.').Last(), name);
+            ReplaceSerializationTypeName(values, splitKey[^1], name);
         }
     }
 
@@ -99,7 +106,7 @@ public static class ValidationProblemExtensions
         string errorName)
         => Regex.Replace(errorName, @"\[.*\]", string.Empty);
 
-    private static void ResolveSerializationTypeName(
+    private static void ReplaceSerializationTypeName(
         IList<string> values,
         string originalName,
         string serializedName)

--- a/src/Atc.Rest.MinimalApi/Extensions/ValidationProblemExtensions.cs
+++ b/src/Atc.Rest.MinimalApi/Extensions/ValidationProblemExtensions.cs
@@ -54,6 +54,12 @@ public static class ValidationProblemExtensions
             var propertyName = RemoveCollectionIndexer(errorName);
             var propertyInfo = subType.GetProperty(propertyName)!;
 
+            if (propertyInfo is null)
+            {
+                depth = depth.Skip(1).ToArray();
+                continue;
+            }
+
             subType = propertyInfo.PropertyType.IsGenericType
                 ? propertyInfo.PropertyType.GenericTypeArguments[0]
                 : propertyInfo.PropertyType;

--- a/src/Atc.Rest.MinimalApi/Filters/Endpoints/ValidationFilter.cs
+++ b/src/Atc.Rest.MinimalApi/Filters/Endpoints/ValidationFilter.cs
@@ -17,7 +17,7 @@ public class ValidationFilter<T> : IEndpointFilter
                         .MergeErrors(
                             await ValidateUsingFluentValidation(context, argToValidate));
 
-        if (errors.Any())
+        if (errors.Count > 0)
         {
             return TypedResults.ValidationProblem(errors)
                 .ResolveSerializationTypeNames<T>();

--- a/src/Atc.Rest.MinimalApi/Filters/Endpoints/ValidationFilter.cs
+++ b/src/Atc.Rest.MinimalApi/Filters/Endpoints/ValidationFilter.cs
@@ -29,21 +29,9 @@ public class ValidationFilter<T> : IEndpointFilter
 
     private static Dictionary<string, string[]> ValidateUsingDataAnnotations(
         object objectToValidate)
-    {
-        var result = new Dictionary<string, string[]>(StringComparer.Ordinal);
-
-        if (MiniValidator.TryValidate(objectToValidate, out var errors))
-        {
-            return result;
-        }
-
-        foreach (var error in errors)
-        {
-            result.Add(error.Key, error.Value);
-        }
-
-        return result;
-    }
+        => MiniValidator.TryValidate(objectToValidate, out var errors)
+            ? new Dictionary<string, string[]>(StringComparer.Ordinal)
+            : new Dictionary<string, string[]>(errors, StringComparer.Ordinal);
 
     private static async Task<Dictionary<string, string[]>> ValidateUsingFluentValidation(
         EndpointFilterInvocationContext context,

--- a/src/Atc.Rest.MinimalApi/Filters/Endpoints/ValidationFilter.cs
+++ b/src/Atc.Rest.MinimalApi/Filters/Endpoints/ValidationFilter.cs
@@ -13,9 +13,9 @@ public class ValidationFilter<T> : IEndpointFilter
             return TypedResults.BadRequest("The request is invalid.");
         }
 
-        var errors = MergeErrors(
-            ValidateUsingDataAnnotations(argToValidate),
-            await ValidateUsingFluentValidation(context, argToValidate));
+        var errors = ValidateUsingDataAnnotations(argToValidate)
+                        .MergeErrors(
+                            await ValidateUsingFluentValidation(context, argToValidate));
 
         if (errors.Any())
         {
@@ -25,30 +25,6 @@ public class ValidationFilter<T> : IEndpointFilter
 
         // Otherwise invoke the next filter in the pipeline
         return await next.Invoke(context);
-    }
-
-    private static IDictionary<string, string[]> MergeErrors(
-        Dictionary<string, string[]> errorsA,
-        Dictionary<string, string[]> errorsB)
-    {
-        var result = new Dictionary<string, string[]>(StringComparer.Ordinal);
-
-        if (!errorsA.Any() &&
-            !errorsB.Any())
-        {
-            return result;
-        }
-
-        return errorsA
-            .Concat(errorsB)
-            .GroupBy(x => x.Key, StringComparer.Ordinal)
-            .ToDictionary(
-                x => x.Key,
-                x => x
-                .SelectMany(y => y.Value)
-                .Distinct(StringComparer.Ordinal)
-                .ToArray(),
-                StringComparer.Ordinal);
     }
 
     private static Dictionary<string, string[]> ValidateUsingDataAnnotations(

--- a/src/Atc.Rest.MinimalApi/GlobalUsings.cs
+++ b/src/Atc.Rest.MinimalApi/GlobalUsings.cs
@@ -1,6 +1,7 @@
 global using System.Diagnostics.CodeAnalysis;
 global using System.Net;
 global using System.Net.Mime;
+global using System.Runtime.CompilerServices;
 global using System.Text;
 global using System.Text.Json;
 global using System.Text.Json.Serialization;

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -54,7 +54,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.119" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -52,3 +52,9 @@ dotnet_diagnostic.SA1133.severity = none            # https://github.com/atc-net
 ##########################################
 # Custom - Code Analyzers Rules
 ##########################################
+dotnet_diagnostic.CA1062.severity = none            # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+
+dotnet_diagnostic.SA1402.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1402.md
+dotnet_diagnostic.SA1649.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1649.md
+
+dotnet_diagnostic.MA0048.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0048.md

--- a/test/Atc.Rest.MinimalApi.Tests/Atc.Rest.MinimalApi.Tests.csproj
+++ b/test/Atc.Rest.MinimalApi.Tests/Atc.Rest.MinimalApi.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <NoWarn>1591;9057</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Atc.Rest.FluentAssertions" Version="2.0.349" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="NSubstituteEquivalency" Version="2.0.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Atc.Rest.MinimalApi\Atc.Rest.MinimalApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Atc.Rest.MinimalApi.Tests/Extensions/ValidationProblemExtensionsTests.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/Extensions/ValidationProblemExtensionsTests.cs
@@ -1,0 +1,131 @@
+namespace Atc.Rest.MinimalApi.Tests.Extensions;
+
+public sealed class ValidationProblemExtensionsTests
+{
+    [Fact]
+    public async Task Should_Not_Throw_NullReferenceException_For_Incorrect_Type_Specified()
+    {
+        // Arrange
+        var fluentValidator = new CreateLocationRequestWithoutJsonPropertyNamesValidator();
+
+        var elementToValidate = new CreateLocationRequestWithoutJsonPropertyNames(
+            new AddressWithoutJsonPropertyNames("DK", "Place", "Street", "PostalCode", "City"),
+            "Telephone");
+
+        var (_, miniValidatorErrors) = await MiniValidator.TryValidateAsync(elementToValidate);
+        var fluentValidatorResults = await fluentValidator.ValidateAsync(elementToValidate);
+
+        // Act
+        var exception = await Record.ExceptionAsync(() =>
+        {
+            TypedResults
+                .ValidationProblem(
+                    miniValidatorErrors
+                        .MergeErrors(fluentValidatorResults.ToDictionary()))
+                .ResolveSerializationTypeNames<DummyTypeWithJsonPropertyName>();
+
+            return Task.CompletedTask;
+        });
+
+        // Assert
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task Should_Validate_Correctly_With_Proper_Casing_For_Type_Without_JsonPropertyName_Attribute()
+    {
+        // Arrange
+        var fluentValidator = new CreateLocationRequestWithoutJsonPropertyNamesValidator();
+
+        var elementToValidate = new CreateLocationRequestWithoutJsonPropertyNames(
+            new AddressWithoutJsonPropertyNames("DK", "Place", "Street", "PostalCode", "City"),
+            "Telephone");
+
+        var (_, miniValidatorErrors) = await MiniValidator.TryValidateAsync(elementToValidate);
+        var fluentValidatorResults = await fluentValidator.TestValidateAsync(elementToValidate);
+
+        // Act
+        var problems = TypedResults
+            .ValidationProblem(
+                miniValidatorErrors
+                    .MergeErrors(fluentValidatorResults.ToDictionary()))
+            .ResolveSerializationTypeNames<CreateLocationRequestWithoutJsonPropertyNames>();
+
+        // Assert
+        using var scope = new AssertionScope();
+        Assert.Single(problems.ProblemDetails.Errors);
+
+        fluentValidatorResults.ShouldHaveValidationErrorFor("Address.CountryCodeA3");
+
+        var (errorKey, errorValues) = problems.ProblemDetails.Errors.First();
+        Assert.True(
+            "Address.CountryCodeA3".Equals(errorKey, StringComparison.Ordinal),
+            "Invalid validation key received.");
+
+        Assert.True(
+            errorValues.Length == 2,
+            "Invalid number of errors received for validation key (expected 1 from DataAnnotations and 1 from FluentValidation).");
+
+        Assert.True(
+            errorValues.Contains("The field CountryCodeA3 must be a string or array type with a minimum length of '3'.", StringComparer.Ordinal),
+            "Missing validation error from DataAnnotations.");
+
+        Assert.True(
+            errorValues.Contains("CountryCodeA3 must be 3 characters long.", StringComparer.Ordinal),
+            "Missing validation error from FluentValidation.");
+    }
+
+    [Fact]
+    public async Task Should_Validate_Correctly_With_Proper_Casing_For_Type_With_JsonPropertyName_Attribute()
+    {
+        // Arrange
+        var fluentValidator = new CreateLocationRequestWithJsonPropertyNamesValidator();
+
+        var elementToValidate = new CreateLocationRequestWithJsonPropertyNames(
+            new AddressWithJsonPropertyNames("DK", "Place", "Street", "PostalCode", "City"),
+            " ");
+
+        var (_, miniValidatorErrors) = await MiniValidator.TryValidateAsync(elementToValidate);
+        var fluentValidatorResults = await fluentValidator.TestValidateAsync(elementToValidate);
+
+        // Act
+        var problems = TypedResults
+            .ValidationProblem(
+                miniValidatorErrors
+                    .MergeErrors(fluentValidatorResults.ToDictionary()))
+            .ResolveSerializationTypeNames<CreateLocationRequestWithJsonPropertyNames>();
+
+        // Assert
+        using var scope = new AssertionScope();
+        Assert.Equal(2, problems.ProblemDetails.Errors.Count);
+
+        fluentValidatorResults.ShouldHaveValidationErrorFor("Address.CountryCodeA3");
+        fluentValidatorResults.ShouldHaveValidationErrorFor("Telephone");
+
+        var (errorKey, errorValues) = problems.ProblemDetails.Errors.First();
+        Assert.True(
+            "address.country_code_a3".Equals(errorKey, StringComparison.Ordinal),
+            "Invalid validation key received.");
+
+        Assert.True(
+            errorValues.Length == 2,
+            "Invalid number of errors received for validation key (expected 1 from DataAnnotations and 1 from FluentValidation).");
+
+        Assert.True(
+            errorValues.Contains("The field country_code_a3 must be a string or array type with a minimum length of '3'.", StringComparer.Ordinal),
+            "Missing validation error from DataAnnotations.");
+
+        Assert.True(
+            errorValues.Contains("country_code_a3 must be 3 characters long.", StringComparer.Ordinal),
+            "Missing validation error from FluentValidation.");
+
+        var (errorKey2, errorValues2) = problems.ProblemDetails.Errors.Last();
+        Assert.True(
+            "telephone".Equals(errorKey2, StringComparison.Ordinal),
+            "Invalid validation key received.");
+
+        Assert.True(
+            errorValues2.Contains("telephone is required.", StringComparer.Ordinal),
+            "Missing validation error from FluentValidation.");
+    }
+}

--- a/test/Atc.Rest.MinimalApi.Tests/GlobalUsings.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/GlobalUsings.cs
@@ -1,0 +1,10 @@
+global using System.ComponentModel.DataAnnotations;
+global using System.Text.Json.Serialization;
+global using Atc.Rest.MinimalApi.Extensions;
+global using Atc.Rest.MinimalApi.Tests.Models;
+global using Atc.Rest.MinimalApi.Tests.Validators;
+global using FluentAssertions.Execution;
+global using FluentValidation;
+global using FluentValidation.TestHelper;
+global using Microsoft.AspNetCore.Http;
+global using MiniValidation;

--- a/test/Atc.Rest.MinimalApi.Tests/Models/AddressWithJsonPropertyNames.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/Models/AddressWithJsonPropertyNames.cs
@@ -1,0 +1,11 @@
+﻿namespace Atc.Rest.MinimalApi.Tests.Models;
+
+public sealed record AddressWithJsonPropertyNames(
+    [MinLength(3)]
+    [MaxLength(3)]
+    [property: JsonPropertyName("country_code_a3")]
+    string CountryCodeA3,
+    string Place,
+    string Street,
+    string PostalCode,
+    string City) : IAddress;

--- a/test/Atc.Rest.MinimalApi.Tests/Models/AddressWithoutJsonPropertyNames.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/Models/AddressWithoutJsonPropertyNames.cs
@@ -1,0 +1,10 @@
+﻿namespace Atc.Rest.MinimalApi.Tests.Models;
+
+public sealed record AddressWithoutJsonPropertyNames(
+    [MinLength(3)]
+    [MaxLength(3)]
+    string CountryCodeA3,
+    string Place,
+    string Street,
+    string PostalCode,
+    string City) : IAddress;

--- a/test/Atc.Rest.MinimalApi.Tests/Models/CreateLocationRequestWithJsonPropertyNames.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/Models/CreateLocationRequestWithJsonPropertyNames.cs
@@ -1,0 +1,7 @@
+﻿namespace Atc.Rest.MinimalApi.Tests.Models;
+
+public sealed record CreateLocationRequestWithJsonPropertyNames(
+    [property: JsonPropertyName("address")]
+    AddressWithJsonPropertyNames Address,
+    [property: JsonPropertyName("telephone")]
+    string Telephone);

--- a/test/Atc.Rest.MinimalApi.Tests/Models/CreateLocationRequestWithoutJsonPropertyNames.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/Models/CreateLocationRequestWithoutJsonPropertyNames.cs
@@ -1,0 +1,5 @@
+namespace Atc.Rest.MinimalApi.Tests.Models;
+
+public sealed record CreateLocationRequestWithoutJsonPropertyNames(
+    AddressWithoutJsonPropertyNames Address,
+    string Telephone);

--- a/test/Atc.Rest.MinimalApi.Tests/Models/DummyTypeWithJsonPropertyName.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/Models/DummyTypeWithJsonPropertyName.cs
@@ -1,0 +1,5 @@
+namespace Atc.Rest.MinimalApi.Tests.Models;
+
+public sealed record DummyTypeWithJsonPropertyName(
+    [property: JsonPropertyName("record_property")]
+    string RecordProperty);

--- a/test/Atc.Rest.MinimalApi.Tests/Models/IAddress.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/Models/IAddress.cs
@@ -1,0 +1,14 @@
+﻿namespace Atc.Rest.MinimalApi.Tests.Models;
+
+public interface IAddress
+{
+    string CountryCodeA3 { get; init; }
+
+    string Place { get; init; }
+
+    string Street { get; init; }
+
+    string PostalCode { get; init; }
+
+    string City { get; init; }
+}

--- a/test/Atc.Rest.MinimalApi.Tests/Validators/AddressValidator.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/Validators/AddressValidator.cs
@@ -1,0 +1,29 @@
+namespace Atc.Rest.MinimalApi.Tests.Validators;
+
+public class AddressValidator<T> : AbstractValidator<T>
+    where T : IAddress
+{
+    public AddressValidator()
+    {
+        RuleFor(x => x.CountryCodeA3)
+            .NotEmpty()
+            .Length(3)
+            .WithMessage("CountryCodeA3 must be 3 characters long.");
+
+        RuleFor(x => x.Place)
+            .NotEmpty()
+            .WithMessage("Place is required.");
+
+        RuleFor(x => x.Street)
+            .NotEmpty()
+            .WithMessage("Street is required.");
+
+        RuleFor(x => x.PostalCode)
+            .NotEmpty()
+            .WithMessage("PostalCode is required.");
+
+        RuleFor(x => x.City)
+            .NotEmpty()
+            .WithMessage("City is required.");
+    }
+}

--- a/test/Atc.Rest.MinimalApi.Tests/Validators/CreateLocationRequestWithJsonPropertyNamesValidator.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/Validators/CreateLocationRequestWithJsonPropertyNamesValidator.cs
@@ -1,0 +1,13 @@
+namespace Atc.Rest.MinimalApi.Tests.Validators;
+
+public sealed class CreateLocationRequestWithJsonPropertyNamesValidator : AbstractValidator<CreateLocationRequestWithJsonPropertyNames>
+{
+    public CreateLocationRequestWithJsonPropertyNamesValidator()
+    {
+        RuleFor(x => x.Address).SetValidator(new AddressValidator<AddressWithJsonPropertyNames>());
+
+        RuleFor(x => x.Telephone)
+            .NotEmpty()
+            .WithMessage("Telephone is required.");
+    }
+}

--- a/test/Atc.Rest.MinimalApi.Tests/Validators/CreateLocationRequestWithoutJsonPropertyNamesValidator.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/Validators/CreateLocationRequestWithoutJsonPropertyNamesValidator.cs
@@ -1,0 +1,13 @@
+namespace Atc.Rest.MinimalApi.Tests.Validators;
+
+public sealed class CreateLocationRequestWithoutJsonPropertyNamesValidator : AbstractValidator<CreateLocationRequestWithoutJsonPropertyNames>
+{
+    public CreateLocationRequestWithoutJsonPropertyNamesValidator()
+    {
+        RuleFor(x => x.Address).SetValidator(new AddressValidator<AddressWithoutJsonPropertyNames>());
+
+        RuleFor(x => x.Telephone)
+            .NotEmpty()
+            .WithMessage("Telephone is required.");
+    }
+}

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc.Test" Version="1.0.72" />
+    <PackageReference Include="Atc.Test" Version="1.0.77" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
This ensures that we dont experience NullReferenceExceptions if an incorrect type is passed to the ResolveSerializationTypeNames<T>.
Also it makes sure, that we can handle models without JsonPropertyNameAttribute.