### PR TITLE
fix: Remove double registrations of endpoints

### DIFF
--- a/src/Atc.Rest.MinimalApi/Extensions/EndpointDefinitionExtensions.cs
+++ b/src/Atc.Rest.MinimalApi/Extensions/EndpointDefinitionExtensions.cs
@@ -66,8 +66,6 @@ public static class EndpointDefinitionExtensions
         {
             endpointDefinition.DefineServices(services);
         }
-
-        services.AddSingleton(endpointDefinitions as IReadOnlyCollection<IEndpointAndServiceDefinition>);
     }
 
     /// <summary>


### PR DESCRIPTION
Remove double registrations of endpoints inherit from IEndpointAndServiceDefinition since IEndpointAndServiceDefinition inherits from IEndpointDefinition