### PR TITLE
Add custom exception-to-status-code mapping to GlobalErrorHandlingMiddleware

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,13 +45,13 @@
 
   <!-- Shared code analyzers used for all projects in the solution -->
   <ItemGroup Label="Code Analyzers">
-    <PackageReference Include="Atc.Analyzer" Version="0.1.15" PrivateAssets="All" />
-    <PackageReference Include="AsyncFixer" Version="1.6.0" PrivateAssets="All" />
+    <PackageReference Include="Atc.Analyzer" Version="0.1.17" PrivateAssets="All" />
+    <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.257" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.267" PrivateAssets="All" />
     <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.16.1.129956" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.17.0.131074" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -436,6 +436,8 @@ The `GlobalErrorHandlingMiddleware` class provides a mechanism for handling unca
 
 This middleware helps in capturing any unhandled exceptions that occur during the request processing pipeline. It translates different types of exceptions into the appropriate HTTP status codes and responds with a standardized error message.
 
+### Basic Usage
+
 An example of how to configure the middleware.
 
 ```csharp
@@ -469,6 +471,46 @@ app.UseGlobalErrorHandler(options =>
     options.UseProblemDetailsAsResponseBody = false;
 });
 ```
+
+### Custom Exception Mapping
+
+The middleware supports mapping custom exception types to specific HTTP status codes. This allows you to define domain-specific exceptions and have them automatically translated to appropriate HTTP responses.
+
+```csharp
+app.UseGlobalErrorHandler(options =>
+{
+    options.MapException<OrderNotFoundException>(HttpStatusCode.NotFound);
+    options.MapException<DuplicateResourceException>(HttpStatusCode.Conflict);
+    options.MapException<QuotaExceededException>(HttpStatusCode.TooManyRequests);
+
+    // For status codes not in HttpStatusCode enum, cast from StatusCodes
+    options.MapException<TeapotException>((HttpStatusCode)StatusCodes.Status418ImATeapot);
+});
+```
+
+**Key features:**
+- **Custom mappings take precedence** over built-in defaults
+- **Inheritance support**: Derived exception types inherit mappings from base types
+- **Method chaining**: Multiple mappings can be chained fluently
+- **Type-safe**: Uses `HttpStatusCode` enum for compile-time safety
+
+### Default Exception Mappings
+
+The following exception types have built-in mappings:
+
+| Exception Type | HTTP Status Code |
+|---------------|------------------|
+| `FluentValidation.ValidationException` | 400 Bad Request |
+| `System.ComponentModel.DataAnnotations.ValidationException` | 400 Bad Request |
+| `BadHttpRequestException` | 400 Bad Request |
+| `ArgumentException` | 400 Bad Request |
+| `UnauthorizedAccessException` | 401 Unauthorized |
+| `InvalidOperationException` | 409 Conflict |
+| `NotImplementedException` | 501 Not Implemented |
+| `TimeoutException` | 504 Gateway Timeout |
+| All other exceptions | 500 Internal Server Error |
+
+You can override any of these defaults by mapping the same exception type to a different status code.
 
 # 💡 Sample Project
 

--- a/sample/Directory.Build.props
+++ b/sample/Directory.Build.props
@@ -45,12 +45,12 @@
 
   <!-- Shared code analyzers used for all projects in the solution -->
   <ItemGroup Label="Code Analyzers">
-    <PackageReference Include="AsyncFixer" Version="1.6.0" PrivateAssets="All" />
+    <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.257" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.267" PrivateAssets="All" />
     <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.16.1.129956" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.17.0.131074" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/sample/src/Demo.Api.Contracts/Demo.Api.Contracts.csproj
+++ b/sample/src/Demo.Api.Contracts/Demo.Api.Contracts.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
-    <PackageReference Include="Atc" Version="3.0.12" />
+    <PackageReference Include="Asp.Versioning.Http" Version="8.1.1" />
+    <PackageReference Include="Atc" Version="3.0.16" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
   </ItemGroup>
 

--- a/sample/src/Demo.Api.Contracts/EndpointDefinitions/SwaggerGroupNames.cs
+++ b/sample/src/Demo.Api.Contracts/EndpointDefinitions/SwaggerGroupNames.cs
@@ -3,4 +3,6 @@ namespace Demo.Api.Contracts.EndpointDefinitions;
 public static class SwaggerGroupNames
 {
     public const string Users = nameof(Users);
+
+    public const string Test = nameof(Test);
 }

--- a/sample/src/Demo.Api.Contracts/EndpointDefinitions/TestEndpointDefinition.cs
+++ b/sample/src/Demo.Api.Contracts/EndpointDefinitions/TestEndpointDefinition.cs
@@ -1,0 +1,34 @@
+namespace Demo.Api.Contracts.EndpointDefinitions;
+
+/// <summary>
+/// Test endpoints for demonstrating custom exception mapping.
+/// </summary>
+public sealed class TestEndpointDefinition : IEndpointDefinition
+{
+    internal const string ApiRouteBase = "/api/test";
+
+    public void DefineEndpoints(
+        WebApplication app)
+    {
+        var test = app.NewVersionedApi(SwaggerGroupNames.Test);
+
+        DefineEndpointsV1(test);
+    }
+
+    private static void DefineEndpointsV1(
+        IEndpointRouteBuilder app)
+    {
+        var testV1 = app
+            .MapGroup(ApiRouteBase)
+            .HasApiVersion(1.0);
+
+        testV1
+            .MapGet("/teapot", ThrowTeapotException)
+            .WithName("ThrowTeapotException")
+            .WithDescription("Throws a TeapotException to demonstrate custom exception mapping to HTTP 418.")
+            .WithSummary("Throws HTTP 418 I'm a teapot");
+    }
+
+    internal static Ok ThrowTeapotException()
+        => throw new TeapotException("I'm a teapot! This demonstrates custom exception mapping.");
+}

--- a/sample/src/Demo.Api.Contracts/Exceptions/TeapotException.cs
+++ b/sample/src/Demo.Api.Contracts/Exceptions/TeapotException.cs
@@ -1,0 +1,35 @@
+namespace Demo.Api.Contracts.Exceptions;
+
+/// <summary>
+/// Custom exception for demonstrating custom exception-to-HTTP-status-code mapping.
+/// Maps to HTTP 418 "I'm a teapot".
+/// </summary>
+public sealed class TeapotException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TeapotException"/> class.
+    /// </summary>
+    public TeapotException()
+        : base("I'm a teapot!")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TeapotException"/> class.
+    /// </summary>
+    /// <param name="message">The exception message.</param>
+    public TeapotException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TeapotException"/> class.
+    /// </summary>
+    /// <param name="message">The exception message.</param>
+    /// <param name="innerException">The inner exception.</param>
+    public TeapotException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/sample/src/Demo.Api.Contracts/GlobalUsings.cs
+++ b/sample/src/Demo.Api.Contracts/GlobalUsings.cs
@@ -9,6 +9,7 @@ global using Demo.Api.Contracts.Contracts.Users.Models.Requests;
 global using Demo.Api.Contracts.Contracts.Users.Models.Responses;
 global using Demo.Api.Contracts.Contracts.Users.Parameters;
 global using Demo.Api.Contracts.EndpointDefinitions;
+global using Demo.Api.Contracts.Exceptions;
 global using Microsoft.AspNetCore.Builder;
 global using Microsoft.AspNetCore.Http;
 global using Microsoft.AspNetCore.Http.HttpResults;

--- a/sample/src/Demo.Api/Demo.Api.csproj
+++ b/sample/src/Demo.Api/Demo.Api.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc" Version="3.0.12" />
-    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
+    <PackageReference Include="Atc" Version="3.0.16" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.11.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.11.10" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/src/Demo.Api/Extensions/WebApplicationExtensions.cs
+++ b/sample/src/Demo.Api/Extensions/WebApplicationExtensions.cs
@@ -15,7 +15,12 @@ public static class WebApplicationExtensions
             handler);
 
     public static IApplicationBuilder AddGlobalErrorHandler(this WebApplication app)
-        => app.UseMiddleware<GlobalErrorHandlingMiddleware>();
+        => app.UseGlobalErrorHandler(options =>
+        {
+            // Demonstrate custom exception mapping: TeapotException -> HTTP 418 I'm a teapot
+            // Note: 418 is not in HttpStatusCode enum, so we cast from StatusCodes
+            options.MapException<TeapotException>((HttpStatusCode)StatusCodes.Status418ImATeapot);
+        });
 
     public static IApplicationBuilder ConfigureSwaggerUI(
         this WebApplication app,

--- a/sample/src/Demo.Api/GlobalUsings.cs
+++ b/sample/src/Demo.Api/GlobalUsings.cs
@@ -1,15 +1,15 @@
 global using System.Globalization;
+global using System.Net;
 global using System.Text;
 global using System.Text.Json;
-
 global using Asp.Versioning;
 global using Asp.Versioning.ApiExplorer;
 global using Atc.Rest.MinimalApi.Extensions;
 global using Atc.Rest.MinimalApi.Filters.Swagger;
-global using Atc.Rest.MinimalApi.Middleware;
 global using Atc.Rest.MinimalApi.Versioning;
 global using Atc.Serialization;
 global using Demo.Api.Contracts;
+global using Demo.Api.Contracts.Exceptions;
 global using Demo.Api.Extensions;
 global using Demo.Api.Options;
 global using Demo.Domain;

--- a/sample/src/Demo.AppHost/Demo.AppHost.csproj
+++ b/sample/src/Demo.AppHost/Demo.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.0.2">
+<Project Sdk="Aspire.AppHost.Sdk/13.1.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/sample/src/Demo.Domain/Demo.Domain.csproj
+++ b/sample/src/Demo.Domain/Demo.Domain.csproj
@@ -5,16 +5,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
+    <PackageReference Include="Asp.Versioning.Http" Version="8.1.1" />
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
-    <PackageReference Include="Atc" Version="3.0.12" />
+    <PackageReference Include="Atc" Version="3.0.16" />
     <PackageReference Include="Atc.Cosmos" Version="1.1.46" />
     <PackageReference Include="Bogus" Version="35.6.5" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="Mapster" Version="7.4.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/src/Demo.Web/Demo.Web.csproj
+++ b/sample/src/Demo.Web/Demo.Web.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc" Version="3.0.12" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
+    <PackageReference Include="Atc" Version="3.0.16" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
     <PackageReference Include="MudBlazor" Version="8.15.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />

--- a/sample/test/Directory.Build.props
+++ b/sample/test/Directory.Build.props
@@ -17,13 +17,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
-    <PackageReference Include="Atc.Rest.FluentAssertions" Version="3.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
+    <PackageReference Include="Atc.Rest.FluentAssertions" Version="3.0.16" />
     <PackageReference Include="Atc.Test" Version="2.0.16" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageReference Include="NSubstituteEquivalency" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.1" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.0.2" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/Atc.Rest.MinimalApi/Atc.Rest.MinimalApi.csproj
+++ b/src/Atc.Rest.MinimalApi/Atc.Rest.MinimalApi.csproj
@@ -13,12 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
-    <PackageReference Include="Atc" Version="3.0.12" />
+    <PackageReference Include="Asp.Versioning.Http" Version="8.1.1" />
+    <PackageReference Include="Atc" Version="3.0.16" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="MiniValidation" Version="0.9.2" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.11.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.0.1" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.11.10" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atc.Rest.MinimalApi/GlobalUsings.cs
+++ b/src/Atc.Rest.MinimalApi/GlobalUsings.cs
@@ -1,3 +1,4 @@
+global using System.Collections.Frozen;
 global using System.Diagnostics.CodeAnalysis;
 global using System.Net;
 global using System.Net.Mime;

--- a/src/Atc.Rest.MinimalApi/Middleware/GlobalErrorHandlingMiddleware.cs
+++ b/src/Atc.Rest.MinimalApi/Middleware/GlobalErrorHandlingMiddleware.cs
@@ -6,6 +6,7 @@ namespace Atc.Rest.MinimalApi.Middleware;
 public sealed partial class GlobalErrorHandlingMiddleware
 {
     private readonly GlobalErrorHandlingOptions options;
+    private readonly ExceptionMappingResolver resolver;
     private readonly RequestDelegate next;
 
     /// <summary>
@@ -17,9 +18,9 @@ public sealed partial class GlobalErrorHandlingMiddleware
         RequestDelegate next,
         GlobalErrorHandlingOptions? options = null)
     {
-        this.options = options ?? new GlobalErrorHandlingOptions();
-
         this.next = next;
+        this.options = options ?? new GlobalErrorHandlingOptions();
+        resolver = this.options.BuildResolver();
     }
 
     /// <summary>
@@ -60,7 +61,7 @@ public sealed partial class GlobalErrorHandlingMiddleware
             return Task.CompletedTask;
         }
 
-        var statusCode = GetHttpStatusCodeByExceptionType(exception);
+        var statusCode = resolver.ResolveStatusCode(exception);
         context.Response.ContentType = MediaTypeNames.Application.Json;
         context.Response.StatusCode = (int)statusCode;
 
@@ -70,26 +71,6 @@ public sealed partial class GlobalErrorHandlingMiddleware
 
         return context.Response.WriteAsync(exceptionResult, context.RequestAborted);
     }
-
-    /// <summary>
-    /// Determines the appropriate HTTP status code based on the exception type.
-    /// </summary>
-    /// <param name="exception">The exception to evaluate.</param>
-    /// <returns>The corresponding HTTP status code.</returns>
-    private static HttpStatusCode GetHttpStatusCodeByExceptionType(
-        Exception exception)
-        => exception switch
-        {
-            FluentValidation.ValidationException => HttpStatusCode.BadRequest,
-            System.ComponentModel.DataAnnotations.ValidationException => HttpStatusCode.BadRequest,
-            BadHttpRequestException => HttpStatusCode.BadRequest,
-            ArgumentException => HttpStatusCode.BadRequest,
-            UnauthorizedAccessException => HttpStatusCode.Unauthorized,
-            InvalidOperationException => HttpStatusCode.Conflict,
-            NotImplementedException => HttpStatusCode.NotImplemented,
-            TimeoutException => HttpStatusCode.GatewayTimeout,
-            _ => HttpStatusCode.InternalServerError,
-        };
 
     /// <summary>
     /// Creates a problem details object to include in the error response.

--- a/src/Atc.Rest.MinimalApi/Options/ExceptionMappingResolver.cs
+++ b/src/Atc.Rest.MinimalApi/Options/ExceptionMappingResolver.cs
@@ -1,0 +1,111 @@
+namespace Atc.Rest.MinimalApi.Options;
+
+/// <summary>
+/// Provides immutable, thread-safe resolution of exception types to HTTP status codes.
+/// </summary>
+internal sealed class ExceptionMappingResolver
+{
+    /// <summary>
+    /// The default mappings used when no custom mapping is found.
+    /// Uses FrozenDictionary for optimal read performance.
+    /// </summary>
+    private static readonly FrozenDictionary<Type, HttpStatusCode> DefaultMappings = new Dictionary<Type, HttpStatusCode>
+    {
+        [typeof(FluentValidation.ValidationException)] = HttpStatusCode.BadRequest,
+        [typeof(System.ComponentModel.DataAnnotations.ValidationException)] = HttpStatusCode.BadRequest,
+        [typeof(BadHttpRequestException)] = HttpStatusCode.BadRequest,
+        [typeof(ArgumentException)] = HttpStatusCode.BadRequest,
+        [typeof(UnauthorizedAccessException)] = HttpStatusCode.Unauthorized,
+        [typeof(InvalidOperationException)] = HttpStatusCode.Conflict,
+        [typeof(NotImplementedException)] = HttpStatusCode.NotImplemented,
+        [typeof(TimeoutException)] = HttpStatusCode.GatewayTimeout,
+    }.ToFrozenDictionary();
+
+    /// <summary>
+    /// Custom mappings dictionary.
+    /// </summary>
+    private readonly FrozenDictionary<Type, HttpStatusCode> customMappings;
+
+    /// <summary>
+    /// Ordered list of custom exception types for inheritance checking.
+    /// Order matters: more specific types should be checked first.
+    /// </summary>
+    private readonly IReadOnlyList<Type> orderedCustomTypes;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExceptionMappingResolver"/> class.
+    /// </summary>
+    /// <param name="mappings">The custom exception mappings in priority order.</param>
+    public ExceptionMappingResolver(
+        IEnumerable<(Type ExceptionType, HttpStatusCode StatusCode)> mappings)
+    {
+        ArgumentNullException.ThrowIfNull(mappings);
+
+        var mappingsList = mappings.ToList();
+
+        customMappings = mappingsList
+            .ToDictionary(m => m.ExceptionType, m => m.StatusCode)
+            .ToFrozenDictionary();
+
+        // Preserve order for inheritance checking
+        orderedCustomTypes = mappingsList
+            .Select(m => m.ExceptionType)
+            .ToList()
+            .AsReadOnly();
+    }
+
+    /// <summary>
+    /// Resolves the HTTP status code for the given exception.
+    /// </summary>
+    /// <param name="exception">The exception to resolve.</param>
+    /// <returns>The HTTP status code.</returns>
+    /// <remarks>
+    /// Resolution order:
+    /// <list type="number">
+    ///   <item><description>Exact match in custom mappings</description></item>
+    ///   <item><description>Inheritance check in custom mappings (ordered, most specific first)</description></item>
+    ///   <item><description>Exact match in default mappings</description></item>
+    ///   <item><description>Inheritance check in default mappings</description></item>
+    ///   <item><description>Fallback to 500 Internal Server Error</description></item>
+    /// </list>
+    /// </remarks>
+    public HttpStatusCode ResolveStatusCode(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        var exceptionType = exception.GetType();
+
+        // 1. Try exact match in custom mappings first
+        if (customMappings.TryGetValue(exceptionType, out var customStatusCode))
+        {
+            return customStatusCode;
+        }
+
+        // 2. Try inheritance check in custom mappings (ordered)
+        foreach (var mappedType in orderedCustomTypes)
+        {
+            if (mappedType.IsAssignableFrom(exceptionType))
+            {
+                return customMappings[mappedType];
+            }
+        }
+
+        // 3. Try exact match in default mappings
+        if (DefaultMappings.TryGetValue(exceptionType, out var defaultStatusCode))
+        {
+            return defaultStatusCode;
+        }
+
+        // 4. Try inheritance check in default mappings
+        foreach (var (mappedType, statusCode) in DefaultMappings)
+        {
+            if (mappedType.IsAssignableFrom(exceptionType))
+            {
+                return statusCode;
+            }
+        }
+
+        // 5. Fallback
+        return HttpStatusCode.InternalServerError;
+    }
+}

--- a/src/Atc.Rest.MinimalApi/Options/GlobalErrorHandlingOptions.cs
+++ b/src/Atc.Rest.MinimalApi/Options/GlobalErrorHandlingOptions.cs
@@ -3,8 +3,10 @@ namespace Atc.Rest.MinimalApi.Options;
 /// <summary>
 /// Provides configuration settings for the global error handling middleware.
 /// </summary>
-public class GlobalErrorHandlingOptions
+public sealed class GlobalErrorHandlingOptions
 {
+    private readonly List<(Type ExceptionType, HttpStatusCode StatusCode)> exceptionMappings = [];
+
     /// <summary>
     /// Gets or sets a value indicating whether the exception details should be included in the error response.
     /// Defaults to <see langword="true"/>.
@@ -23,7 +25,76 @@ public class GlobalErrorHandlingOptions
     /// </value>
     public bool UseProblemDetailsAsResponseBody { get; set; } = true;
 
+    /// <summary>
+    /// Maps an exception type to a specific HTTP status code.
+    /// Custom mappings take precedence over built-in default mappings.
+    /// Inheritance is supported: derived exception types are checked before base types.
+    /// </summary>
+    /// <typeparam name="TException">The type of exception to map.</typeparam>
+    /// <param name="statusCode">The HTTP status code to return when this exception type is thrown.</param>
+    /// <returns>The current options instance for method chaining.</returns>
+    /// <example>
+    /// <code>
+    /// options.MapException&lt;OrderNotFoundException&gt;(HttpStatusCode.NotFound);
+    /// options.MapException&lt;DuplicateResourceException&gt;(HttpStatusCode.Conflict);
+    /// </code>
+    /// </example>
+    public GlobalErrorHandlingOptions MapException<TException>(
+        HttpStatusCode statusCode)
+        where TException : Exception
+    {
+        var exceptionType = typeof(TException);
+
+        // Remove existing mapping if present (allows overwriting)
+        exceptionMappings.RemoveAll(m => m.ExceptionType == exceptionType);
+
+        // Add to the beginning for precedence (most recently added = highest priority)
+        exceptionMappings.Insert(0, (exceptionType, statusCode));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Maps an exception type to a specific HTTP status code using a non-generic overload.
+    /// </summary>
+    /// <param name="exceptionType">The type of exception to map. Must derive from <see cref="Exception"/>.</param>
+    /// <param name="statusCode">The HTTP status code to return when this exception type is thrown.</param>
+    /// <returns>The current options instance for method chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="exceptionType"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="exceptionType"/> does not derive from <see cref="Exception"/>.</exception>
+    public GlobalErrorHandlingOptions MapException(
+        Type exceptionType,
+        HttpStatusCode statusCode)
+    {
+        ArgumentNullException.ThrowIfNull(exceptionType);
+
+        if (!typeof(Exception).IsAssignableFrom(exceptionType))
+        {
+            throw new ArgumentException(
+                $"Type '{exceptionType.FullName}' must derive from System.Exception.",
+                nameof(exceptionType));
+        }
+
+        // Remove existing mapping if present
+        exceptionMappings.RemoveAll(m => m.ExceptionType == exceptionType);
+
+        // Add to the beginning for precedence
+        exceptionMappings.Insert(0, (exceptionType, statusCode));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Builds an immutable exception mapping resolver from the configured mappings.
+    /// This method should be called once after all mappings have been configured.
+    /// </summary>
+    /// <returns>An immutable resolver that can be used by the middleware.</returns>
+    internal ExceptionMappingResolver BuildResolver()
+        => new(exceptionMappings);
+
     /// <inheritdoc />
     public override string ToString()
-        => $"{nameof(IncludeException)}: {IncludeException}, {nameof(UseProblemDetailsAsResponseBody)}: {UseProblemDetailsAsResponseBody}";
+        => $"{nameof(IncludeException)}: {IncludeException}, " +
+           $"{nameof(UseProblemDetailsAsResponseBody)}: {UseProblemDetailsAsResponseBody}, " +
+           $"CustomMappings: {exceptionMappings.Count}";
 }

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -55,6 +55,7 @@ dotnet_diagnostic.SA1133.severity = none            # https://github.com/atc-net
 # Custom - Code Analyzers Rules
 ##########################################
 dotnet_diagnostic.CA1062.severity = none            # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1062
+dotnet_diagnostic.CA1515.severity = none            # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1515
 dotnet_diagnostic.CA2000.severity = none            # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2000
 
 dotnet_diagnostic.SA1402.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1402.md

--- a/test/Atc.Rest.MinimalApi.Tests/Exceptions/TeapotTestException.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/Exceptions/TeapotTestException.cs
@@ -1,0 +1,23 @@
+namespace Atc.Rest.MinimalApi.Tests.Exceptions;
+
+/// <summary>
+/// Test exception for demonstrating custom exception mapping.
+/// </summary>
+public sealed class TeapotTestException : Exception
+{
+    public TeapotTestException()
+    {
+    }
+
+    public TeapotTestException(string message)
+        : base(message)
+    {
+    }
+
+    public TeapotTestException(
+        string message,
+        Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/test/Atc.Rest.MinimalApi.Tests/GlobalUsings.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/GlobalUsings.cs
@@ -1,4 +1,5 @@
 global using System.ComponentModel.DataAnnotations;
+global using System.Net;
 global using System.Runtime.CompilerServices;
 global using System.Text.Json;
 global using System.Text.Json.Nodes;
@@ -10,6 +11,7 @@ global using Atc.Rest.MinimalApi.Filters.Endpoints;
 global using Atc.Rest.MinimalApi.Filters.Swagger;
 global using Atc.Rest.MinimalApi.Middleware;
 global using Atc.Rest.MinimalApi.Options;
+global using Atc.Rest.MinimalApi.Tests.Exceptions;
 global using Atc.Rest.MinimalApi.Tests.Models;
 global using Atc.Rest.MinimalApi.Tests.Validators;
 global using FluentAssertions.Execution;

--- a/test/Atc.Rest.MinimalApi.Tests/Middleware/GlobalErrorHandlingMiddlewareTests.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/Middleware/GlobalErrorHandlingMiddlewareTests.cs
@@ -107,4 +107,146 @@ public sealed class GlobalErrorHandlingMiddlewareTests
             .Should()
             .Be("Conflict");
     }
+
+    [Fact]
+    public async Task Invoke_WithCustomMapping_ReturnsCustomStatusCode()
+    {
+        // Arrange
+        var options = new GlobalErrorHandlingOptions
+        {
+            UseProblemDetailsAsResponseBody = false,
+        };
+
+        options.MapException<KeyNotFoundException>(HttpStatusCode.NotFound);
+
+        var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+
+        var middleware = new GlobalErrorHandlingMiddleware(
+            next: _ => throw new KeyNotFoundException("Resource not found"),
+            options: options);
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert
+        context.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        var responseBody = await new StreamReader(context.Response.Body).ReadToEndAsync(TestContext.Current.CancellationToken);
+
+        using var doc = JsonDocument.Parse(responseBody);
+        doc.RootElement
+            .GetProperty("status")
+            .GetInt32()
+            .Should()
+            .Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task Invoke_WithInheritedCustomMapping_ReturnsBaseTypeStatusCode()
+    {
+        // Arrange - FileNotFoundException derives from IOException
+        var options = new GlobalErrorHandlingOptions
+        {
+            UseProblemDetailsAsResponseBody = false,
+        };
+
+        options.MapException<IOException>(HttpStatusCode.ServiceUnavailable);
+
+        var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+
+        var middleware = new GlobalErrorHandlingMiddleware(
+            next: _ => throw new FileNotFoundException("File not found"),
+            options: options);
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert - FileNotFoundException should match IOException mapping via inheritance
+        context.Response.StatusCode.Should().Be(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task Invoke_CustomMappingTakesPrecedenceOverDefault()
+    {
+        // Arrange - Override default ArgumentException mapping (400 -> 422)
+        var options = new GlobalErrorHandlingOptions
+        {
+            UseProblemDetailsAsResponseBody = false,
+        };
+
+        options.MapException<ArgumentException>(HttpStatusCode.UnprocessableEntity);
+
+        var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+
+        var middleware = new GlobalErrorHandlingMiddleware(
+            next: _ => throw new ArgumentException("Invalid argument"),
+            options: options);
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert - Should be 422, not the default 400
+        context.Response.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    [Fact]
+    public void MapException_NonGeneric_WithNonExceptionType_ThrowsArgumentException()
+    {
+        // Arrange
+        var options = new GlobalErrorHandlingOptions();
+
+        // Act & Assert
+        var act = () => options.MapException(typeof(string), HttpStatusCode.BadRequest);
+        act
+            .Should()
+            .Throw<ArgumentException>()
+            .WithParameterName("exceptionType");
+    }
+
+    [Fact]
+    public void MapException_SupportsMethodChaining()
+    {
+        // Arrange & Act
+        var options = new GlobalErrorHandlingOptions()
+            .MapException<KeyNotFoundException>(HttpStatusCode.NotFound)
+            .MapException<InvalidOperationException>(HttpStatusCode.UnprocessableEntity)
+            .MapException<UnauthorizedAccessException>(HttpStatusCode.Forbidden);
+
+        // Assert - Just verify no exception is thrown and chaining works
+        options.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Invoke_WithTeapotMapping_Returns418()
+    {
+        // Arrange - Demonstrate custom exception with 418 I'm a teapot (not in HttpStatusCode enum)
+        var options = new GlobalErrorHandlingOptions
+        {
+            UseProblemDetailsAsResponseBody = true,
+        };
+        options.MapException<TeapotTestException>((HttpStatusCode)StatusCodes.Status418ImATeapot);
+
+        var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+
+        var middleware = new GlobalErrorHandlingMiddleware(
+            next: _ => throw new TeapotTestException("I'm a teapot!"),
+            options: options);
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert
+        context.Response.StatusCode.Should().Be(418);
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        var responseBody = await new StreamReader(context.Response.Body).ReadToEndAsync(TestContext.Current.CancellationToken);
+
+        using var doc = JsonDocument.Parse(responseBody);
+        doc.RootElement
+            .GetProperty("status")
+            .GetInt32()
+            .Should()
+            .Be(StatusCodes.Status418ImATeapot);
+    }
 }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -17,13 +17,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc.Rest.FluentAssertions" Version="3.0.12" />
+    <PackageReference Include="Atc.Rest.FluentAssertions" Version="3.0.16" />
     <PackageReference Include="Atc.Test" Version="2.0.16" />
-    <PackageReference Include="Atc.XUnit" Version="3.0.12" />
+    <PackageReference Include="Atc.XUnit" Version="3.0.16" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageReference Include="NSubstituteEquivalency" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.1" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.0.2" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
## Summary

  Add the ability to map custom exception types to specific HTTP status codes in `GlobalErrorHandlingMiddleware`. This enables domain-specific exceptions to be automatically translated to appropriate HTTP responses.

  ## Changes

  ### New Feature: Custom Exception Mapping

  - Add `MapException<T>(HttpStatusCode)` fluent API to `GlobalErrorHandlingOptions`
  - Add `ExceptionMappingResolver` for immutable, thread-safe status code resolution
  - Support inheritance: derived exception types inherit base type mappings
  - Custom mappings take precedence over built-in defaults
  - Type-safe API using `HttpStatusCode` enum

  ### Usage Example

  ```csharp
  app.UseGlobalErrorHandler(options =>
  {
      options.MapException<OrderNotFoundException>(HttpStatusCode.NotFound);
      options.MapException<DuplicateResourceException>(HttpStatusCode.Conflict);

      // For exotic status codes not in HttpStatusCode enum
      options.MapException<TeapotException>((HttpStatusCode)StatusCodes.Status418ImATeapot);
  });

  Sample & Documentation

  - Add GET /api/test/teapot endpoint demonstrating HTTP 418 response
  - Add TeapotException as example custom exception
  - Update README with custom exception mapping documentation