### PR TITLE
fix(middleware): map non-disconnect OperationCanceled to 504

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.0
-# Updated: 01-03-2025
+# Version: 1.0.1
+# Updated: 20-04-2026
 # Location: Root
 # Distribution: DotNet10
 # Inspired by: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
@@ -441,28 +441,24 @@ dotnet_naming_rule.parameters_rule.severity             = warning
 # http://www.asyncfixer.com
 
 
-# Asyncify
-# https://github.com/hvanbakel/Asyncify-CSharp
-
-
 # Meziantou
 # https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
-dotnet_diagnostic.MA0003.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0003.md
-dotnet_diagnostic.MA0004.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0004.md
-dotnet_diagnostic.MA0006.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0006.md
+dotnet_diagnostic.MA0003.severity = suggestion      # Add argument name to improve readability
+dotnet_diagnostic.MA0004.severity = suggestion      # Use Task.ConfigureAwait(false)
+dotnet_diagnostic.MA0006.severity = none            # Use String.Equals instead of equality operator
 dotnet_diagnostic.MA0011.severity = none            # Duplicate of CA1305
-dotnet_diagnostic.MA0016.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0016.md
-dotnet_diagnostic.MA0025.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0025.md
-dotnet_diagnostic.MA0026.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0026.md
-dotnet_diagnostic.MA0028.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0028.md
+dotnet_diagnostic.MA0016.severity = error           # Prefer return collection abstraction over implementation
+dotnet_diagnostic.MA0025.severity = suggestion      # Implement functionality instead of throwing NotImplementedException
+dotnet_diagnostic.MA0026.severity = suggestion      # Fix TODO comment
+dotnet_diagnostic.MA0028.severity = none            # Optimize StringBuilder usage
 dotnet_diagnostic.MA0038.severity = none            # Duplicate of CA1822
-dotnet_diagnostic.MA0048.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0048.md
+dotnet_diagnostic.MA0048.severity = error           # File name must match type name
 
 
 # Microsoft - Code Analysis
 # https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/
-dotnet_diagnostic.CA1014.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1014.md
-dotnet_diagnostic.CA1068.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1068.md
+dotnet_diagnostic.CA1014.severity = none            # Mark assemblies with CLSCompliantAttribute
+dotnet_diagnostic.CA1068.severity = error           # CancellationToken parameters must come last
 dotnet_diagnostic.CA1305.severity = error
 dotnet_diagnostic.CA1308.severity = suggestion      # Normalize strings to uppercase
 dotnet_diagnostic.CA1510.severity = suggestion      # Use ArgumentNullException throw helper
@@ -471,7 +467,7 @@ dotnet_diagnostic.CA1512.severity = suggestion      # Use ArgumentOutOfRangeExce
 dotnet_diagnostic.CA1513.severity = suggestion      # Use ObjectDisposedException throw helper
 dotnet_diagnostic.CA1514.severity = error           # Avoid redundant length argument
 dotnet_diagnostic.CA1515.severity = suggestion      # Because an application's API isn't typically referenced from outside the assembly, types can be made internal (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1515)
-dotnet_diagnostic.CA1707.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1707.md
+dotnet_diagnostic.CA1707.severity = error           # Identifiers should not contain underscores
 dotnet_diagnostic.CA1812.severity = none
 dotnet_diagnostic.CA1822.severity = suggestion
 dotnet_diagnostic.CA1849.severity = error           # Call async methods when in an async method
@@ -494,7 +490,11 @@ dotnet_diagnostic.CA1869.severity = suggestion      # Cache and reuse 'JsonSeria
 dotnet_diagnostic.CA1870.severity = suggestion      # Use a cached 'SearchValues' instance
 dotnet_diagnostic.CA1871.severity = suggestion      # Do not pass a nullable struct to 'ArgumentNullException.ThrowIfNull'
 dotnet_diagnostic.CA1872.severity = suggestion      # Prefer 'Convert.ToHexString' and 'Convert.ToHexStringLower' over call chains based on 'BitConverter.ToString'
-dotnet_diagnostic.CA2007.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA2007.md
+dotnet_diagnostic.CA1873.severity = suggestion      # Avoid potentially expensive logging (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1873)
+dotnet_diagnostic.CA1874.severity = suggestion      # Use 'Regex.IsMatch' instead of 'Regex.Match(...).Success' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1874)
+dotnet_diagnostic.CA1875.severity = suggestion      # Use 'Regex.Count' instead of 'Regex.Matches(...).Count' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1875)
+dotnet_diagnostic.CA1877.severity = suggestion      # Use 'Path.Combine' or 'Path.Join' overloads (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1877)
+dotnet_diagnostic.CA2007.severity = suggestion      # Do not directly await a Task
 dotnet_diagnostic.CA2017.severity = error           # Parameter count mismatch
 dotnet_diagnostic.CA2018.severity = error           # The count argument to Buffer.BlockCopy should specify the number of bytes to copy
 dotnet_diagnostic.CA2019.severity = error           # ThreadStatic fields should not use inline initialization
@@ -510,12 +510,13 @@ dotnet_diagnostic.CA2261.severity = error           # Do not use ConfigureAwaitO
 dotnet_diagnostic.CA2262.severity = suggestion      # Set 'MaxResponseHeadersLength' properly
 dotnet_diagnostic.CA2263.severity = suggestion      # Prefer generic overload when type is known
 dotnet_diagnostic.CA2264.severity = error           # Do not pass a non-nullable value to 'ArgumentNullException.ThrowIfNull'
-dotnet_diagnostic.IDE0005.severity = warning        # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/IDE0005.md
+dotnet_diagnostic.CA2265.severity = error           # Do not compare Sp an<T> to 'null' or 'default' (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2265)
+dotnet_diagnostic.IDE0005.severity = warning        # Remove unnecessary using directives
 dotnet_diagnostic.IDE0010.severity = suggestion     # Populate switch
 dotnet_diagnostic.IDE0028.severity = suggestion     # Collection initialization can be simplified
 dotnet_diagnostic.IDE0021.severity = suggestion     # Use expression body for constructor
 dotnet_diagnostic.IDE0055.severity = none           # Fix formatting
-dotnet_diagnostic.IDE0058.severity = none           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/IDE0058.md
+dotnet_diagnostic.IDE0058.severity = none           # Remove unnecessary expression value
 dotnet_diagnostic.IDE0061.severity = suggestion     # Use expression body for local function
 dotnet_diagnostic.IDE0130.severity = suggestion     # Namespace does not match folder structure
 dotnet_diagnostic.IDE0290.severity = none			# Use primary constructor
@@ -525,38 +526,34 @@ dotnet_diagnostic.IDE0305.severity = suggestion     # Collection initialization 
 
 # Microsoft - Compiler Errors
 # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/
-dotnet_diagnostic.CS4014.severity = error          # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCompilerErrors/CS4014.md
-
-
-# SecurityCodeScan
-# https://security-code-scan.github.io/
+dotnet_diagnostic.CS4014.severity = error           # Call is not awaited
 
 
 # StyleCop
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers
-dotnet_diagnostic.SA1009.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1009.md
+dotnet_diagnostic.SA1009.severity = none            # Closing parenthesis should be spaced correctly
 dotnet_diagnostic.SA1010.severity = none            # False positive when using collection initializers
-dotnet_diagnostic.SA1101.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1101.md
-dotnet_diagnostic.SA1122.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1122.md
-dotnet_diagnostic.SA1133.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1133.md
-dotnet_diagnostic.SA1200.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1200.md
-dotnet_diagnostic.SA1201.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1201.md
-dotnet_diagnostic.SA1202.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1202.md
-dotnet_diagnostic.SA1204.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1204.md
-dotnet_diagnostic.SA1413.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1413.md
-dotnet_diagnostic.SA1600.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1600.md
+dotnet_diagnostic.SA1101.severity = none            # Prefix local calls with this
+dotnet_diagnostic.SA1122.severity = error           # Use string.Empty for empty strings
+dotnet_diagnostic.SA1133.severity = error           # Do not combine attributes
+dotnet_diagnostic.SA1200.severity = none            # Using directives should be placed correctly
+dotnet_diagnostic.SA1201.severity = none            # Elements should appear in the correct order
+dotnet_diagnostic.SA1202.severity = none            # Elements should be ordered by access
+dotnet_diagnostic.SA1204.severity = none            # Static elements should appear before instance elements
+dotnet_diagnostic.SA1413.severity = error           # Use trailing commas in multi-line initializers
+dotnet_diagnostic.SA1600.severity = none            # Elements should be documented
 dotnet_diagnostic.SA1601.severity = none
-dotnet_diagnostic.SA1602.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1602.md
-dotnet_diagnostic.SA1604.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1604.md
-dotnet_diagnostic.SA1623.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1623.md
-dotnet_diagnostic.SA1629.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1629.md
-dotnet_diagnostic.SA1633.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1633.md
-dotnet_diagnostic.SA1649.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1649.md
+dotnet_diagnostic.SA1602.severity = none            # Enumeration items should be documented
+dotnet_diagnostic.SA1604.severity = none            # Element documentation should have summary
+dotnet_diagnostic.SA1623.severity = none            # Property summary documentation should match accessors
+dotnet_diagnostic.SA1629.severity = none            # Documentation text should end with a period
+dotnet_diagnostic.SA1633.severity = none            # File should have header
+dotnet_diagnostic.SA1649.severity = error           # File name should match first type name
 
 
 # SonarAnalyzer.CSharp
 # https://rules.sonarsource.com/csharp
-dotnet_diagnostic.S1135.severity = suggestion       # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/SonarAnalyzerCSharp/S1135.md
+dotnet_diagnostic.S1135.severity = suggestion       # Track uses of TODO tags
 dotnet_diagnostic.S2629.severity = none            	# Don't use string interpolation in logging message templates.
 dotnet_diagnostic.S3358.severity = none           	# Extract this nested ternary operation into an independent statement.
 dotnet_diagnostic.S6602.severity = none           	# "Find" method should be used instead of the "FirstOrDefault"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,13 +45,11 @@
 
   <!-- Shared code analyzers used for all projects in the solution -->
   <ItemGroup Label="Code Analyzers">
-    <PackageReference Include="Atc.Analyzer" Version="0.1.17" PrivateAssets="All" />
+    <PackageReference Include="Atc.Analyzer" Version="0.1.23" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
-    <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.267" PrivateAssets="All" />
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.58" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.17.0.131074" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.25.0.139117" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/sample/Directory.Build.props
+++ b/sample/Directory.Build.props
@@ -45,12 +45,11 @@
 
   <!-- Shared code analyzers used for all projects in the solution -->
   <ItemGroup Label="Code Analyzers">
+    <PackageReference Include="Atc.Analyzer" Version="0.1.23" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
-    <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.267" PrivateAssets="All" />
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.58" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.17.0.131074" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.25.0.139117" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/sample/src/Demo.Api.Contracts/Demo.Api.Contracts.csproj
+++ b/sample/src/Demo.Api.Contracts/Demo.Api.Contracts.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Asp.Versioning.Http" Version="8.1.1" />
-    <PackageReference Include="Atc" Version="3.0.16" />
+    <PackageReference Include="Asp.Versioning.Http" Version="10.0.0" />
+    <PackageReference Include="Atc" Version="3.0.67" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
   </ItemGroup>
 

--- a/sample/src/Demo.Api.Contracts/EndpointDefinitions/TestEndpointDefinition.cs
+++ b/sample/src/Demo.Api.Contracts/EndpointDefinitions/TestEndpointDefinition.cs
@@ -7,16 +7,14 @@ public sealed class TestEndpointDefinition : IEndpointDefinition
 {
     internal const string ApiRouteBase = "/api/test";
 
-    public void DefineEndpoints(
-        WebApplication app)
+    public void DefineEndpoints(WebApplication app)
     {
         var test = app.NewVersionedApi(SwaggerGroupNames.Test);
 
         DefineEndpointsV1(test);
     }
 
-    private static void DefineEndpointsV1(
-        IEndpointRouteBuilder app)
+    private static void DefineEndpointsV1(IEndpointRouteBuilder app)
     {
         var testV1 = app
             .MapGroup(ApiRouteBase)

--- a/sample/src/Demo.Api.Contracts/EndpointDefinitions/UsersEndpointDefinition.cs
+++ b/sample/src/Demo.Api.Contracts/EndpointDefinitions/UsersEndpointDefinition.cs
@@ -4,16 +4,14 @@ public sealed class UsersEndpointDefinition : IEndpointDefinition
 {
     internal const string ApiRouteBase = "/api/users";
 
-    public void DefineEndpoints(
-        WebApplication app)
+    public void DefineEndpoints(WebApplication app)
     {
         var users = app.NewVersionedApi(SwaggerGroupNames.Users);
 
         DefineEndpointsV1(users);
     }
 
-    private void DefineEndpointsV1(
-        IEndpointRouteBuilder app)
+    private void DefineEndpointsV1(IEndpointRouteBuilder app)
     {
         var usersV1 = app
             .MapGroup(ApiRouteBase)

--- a/sample/src/Demo.Api.Contracts/Exceptions/TeapotException.cs
+++ b/sample/src/Demo.Api.Contracts/Exceptions/TeapotException.cs
@@ -28,7 +28,9 @@ public sealed class TeapotException : Exception
     /// </summary>
     /// <param name="message">The exception message.</param>
     /// <param name="innerException">The inner exception.</param>
-    public TeapotException(string message, Exception innerException)
+    public TeapotException(
+        string message,
+        Exception innerException)
         : base(message, innerException)
     {
     }

--- a/sample/src/Demo.Api/Demo.Api.csproj
+++ b/sample/src/Demo.Api/Demo.Api.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc" Version="3.0.16" />
-    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
+    <PackageReference Include="Atc" Version="3.0.67" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.11.10" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.14.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/src/Demo.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/sample/src/Demo.Api/Extensions/ServiceCollectionExtensions.cs
@@ -2,8 +2,7 @@ namespace Demo.Api.Extensions;
 
 public static class ServiceCollectionExtensions
 {
-    public static void ConfigureApiVersioning(
-        this IServiceCollection services)
+    public static void ConfigureApiVersioning(this IServiceCollection services)
     {
         services.AddEndpointsApiExplorer();
         services.AddApiVersioning(
@@ -41,8 +40,7 @@ public static class ServiceCollectionExtensions
             });
     }
 
-    public static void ConfigureSwagger(
-        this IServiceCollection services)
+    public static void ConfigureSwagger(this IServiceCollection services)
     {
         services.AddTransient<IConfigureOptions<SwaggerGenOptions>, ConfigureSwaggerOptions>();
         services.AddSwaggerGen(options =>

--- a/sample/src/Demo.Api/Extensions/WebApplicationExtensions.cs
+++ b/sample/src/Demo.Api/Extensions/WebApplicationExtensions.cs
@@ -14,7 +14,8 @@ public static class WebApplicationExtensions
             PatchHttpMethods,
             handler);
 
-    public static IApplicationBuilder AddGlobalErrorHandler(this WebApplication app)
+    public static IApplicationBuilder AddGlobalErrorHandler(
+        this WebApplication app)
         => app.UseGlobalErrorHandler(options =>
         {
             // Demonstrate custom exception mapping: TeapotException -> HTTP 418 I'm a teapot

--- a/sample/src/Demo.Api/GlobalUsings.cs
+++ b/sample/src/Demo.Api/GlobalUsings.cs
@@ -5,6 +5,7 @@ global using System.Text.Json;
 global using Asp.Versioning;
 global using Asp.Versioning.ApiExplorer;
 global using Atc.Rest.MinimalApi.Extensions;
+global using Atc.Rest.MinimalApi.Filters.Endpoints;
 global using Atc.Rest.MinimalApi.Filters.Swagger;
 global using Atc.Rest.MinimalApi.Versioning;
 global using Atc.Serialization;

--- a/sample/src/Demo.Api/Options/ConfigureSwaggerOptions.cs
+++ b/sample/src/Demo.Api/Options/ConfigureSwaggerOptions.cs
@@ -34,7 +34,8 @@ public class ConfigureSwaggerOptions : IConfigureOptions<SwaggerGenOptions>
         }
     }
 
-    private OpenApiInfo CreateInfoForApiVersion(ApiVersionDescription description)
+    private OpenApiInfo CreateInfoForApiVersion(
+        ApiVersionDescription description)
     {
         var text = new StringBuilder("An example API to showcase minimal api implementation using the Atc.Rest.MinimalApi Nuget package.");
         var info = new OpenApiInfo

--- a/sample/src/Demo.Api/Program.cs
+++ b/sample/src/Demo.Api/Program.cs
@@ -1,5 +1,3 @@
-using Atc.Rest.MinimalApi.Filters.Endpoints;
-
 var builder = WebApplication.CreateBuilder(args);
 
 builder.ConfigureLogging();

--- a/sample/src/Demo.AppHost/.editorconfig
+++ b/sample/src/Demo.AppHost/.editorconfig
@@ -1,0 +1,80 @@
+# ATC coding rules - https://github.com/atc-net/atc-coding-rules
+# Version: 1.1.0
+# Updated: 24-04-2026
+# Location: aspire
+# Distribution: Frameworks
+
+##########################################
+# Code Analyzers Rules
+##########################################
+[*.{cs}]
+
+# Meziantou
+# https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
+dotnet_diagnostic.MA0004.severity = none            # Use Task.ConfigureAwait(false) - Not needed in Aspire AppHost https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0004.md
+
+# SonarAnalyzer.CSharp
+# https://rules.sonarsource.com/csharp
+dotnet_diagnostic.S6964.severity = none             # Value type property validation - may conflict with Aspire resource builders
+
+##########################################
+# .NET Aspire Diagnostics Reference
+# https://aspire.dev/diagnostics/overview/
+#
+# The following ASPIRE rules use SDK defaults and are NOT explicitly configured.
+# Uncomment and adjust as needed for your project:
+#
+# MSBuild Warnings:
+# dotnet_diagnostic.ASPIRE001.severity = warning                     # Language isn't fully supported by Aspire
+# dotnet_diagnostic.ASPIRE002.severity = warning                     # Missing Aspire.Hosting.AppHost package
+# dotnet_diagnostic.ASPIRE003.severity = warning                     # Requires Visual Studio 17.10+
+# dotnet_diagnostic.ASPIRE004.severity = warning                     # Non-executable referenced by AppHost
+# dotnet_diagnostic.ASPIRE006.severity = error                       # Application model items must have valid names
+# dotnet_diagnostic.ASPIRE007.severity = error                       # Requires Aspire.AppHost.Sdk 9.0.0+
+# dotnet_diagnostic.ASPIRE008.severity = error                       # Requires GenerateAssemblyInfo to be enabled
+#
+# Experimental API Warnings (suppress if using these features):
+# dotnet_diagnostic.ASPIREACADOMAINS001.severity = none              # Azure Container Apps custom domains
+# dotnet_diagnostic.ASPIREATS001.severity = none                     # Aspire Type Specification (ATS) types
+# dotnet_diagnostic.ASPIREAZURE001.severity = none                   # Azure publishers
+# dotnet_diagnostic.ASPIREAZURE002.severity = none                   # Azure Container App Jobs
+# dotnet_diagnostic.ASPIREAZURE003.severity = none                   # Azure Virtual Network types
+# dotnet_diagnostic.ASPIRECERTIFICATES001.severity = none            # Certificate configuration types
+# dotnet_diagnostic.ASPIRECOMPUTE001.severity = none                 # Custom compute environments
+# dotnet_diagnostic.ASPIRECOMPUTE002.severity = none                 # GetHostAddressExpression method
+# dotnet_diagnostic.ASPIRECOMPUTE003.severity = none                 # ContainerRegistryResource type
+# dotnet_diagnostic.ASPIRECONTAINERRUNTIME001.severity = none        # Container runtime types
+# dotnet_diagnostic.ASPIRECONTAINERSHELLEXECUTION001.severity = none # Container shell execution property
+# dotnet_diagnostic.ASPIRECOSMOSDB001.severity = none                # CosmosDB preview emulator
+# dotnet_diagnostic.ASPIRECSHARPAPPS001.severity = none              # AddCSharpApp
+# dotnet_diagnostic.ASPIREDOCKERFILEBUILDER001.severity = none       # Dockerfile builder types
+# dotnet_diagnostic.ASPIREDOTNETTOOL.severity = none                 # .NET tool resource types
+# dotnet_diagnostic.ASPIREEXPORT001.severity = error                 # Exported method must be static
+# dotnet_diagnostic.ASPIREEXPORT002.severity = error                 # Invalid export ID format
+# dotnet_diagnostic.ASPIREEXPORT003.severity = error                 # Return type incompatible with ATS
+# dotnet_diagnostic.ASPIREEXPORT004.severity = error                 # Parameter type incompatible with ATS
+# dotnet_diagnostic.ASPIREEXPORT005.severity = warning               # Union types require 2+ constituents
+# dotnet_diagnostic.ASPIREEXPORT006.severity = warning               # Union type incompatible with ATS
+# dotnet_diagnostic.ASPIREEXPORT007.severity = warning               # Duplicate export ID
+# dotnet_diagnostic.ASPIREEXPORT008.severity = warning               # Public extension missing required attribute
+# dotnet_diagnostic.ASPIREEXPORT009.severity = warning               # Export name risks collision
+# dotnet_diagnostic.ASPIREEXPORT010.severity = warning               # Synchronous inline callback / potential deadlock
+# dotnet_diagnostic.ASPIREEXTENSION001.severity = none               # Extension debugging support APIs
+# dotnet_diagnostic.ASPIREFILESYSTEM001.severity = none              # File system service types
+# dotnet_diagnostic.ASPIREHOSTINGPYTHON001.severity = none           # Python app orchestration
+# dotnet_diagnostic.ASPIREINTERACTION001.severity = none             # Interaction service types
+# dotnet_diagnostic.ASPIREMCP001.severity = none                     # MCP server types
+# dotnet_diagnostic.ASPIREPIPELINES001.severity = none               # Deployment pipeline infrastructure
+# dotnet_diagnostic.ASPIREPIPELINES002.severity = none               # Deployment state manager
+# dotnet_diagnostic.ASPIREPIPELINES003.severity = none               # Container image build
+# dotnet_diagnostic.ASPIREPIPELINES004.severity = none               # Pipeline types under evaluation
+# dotnet_diagnostic.ASPIREPOSTGRES001.severity = none                # PostgreSQL MCP integration
+# dotnet_diagnostic.ASPIREPROBES001.severity = none                  # Probe-related types
+# dotnet_diagnostic.ASPIREPROXYENDPOINTS001.severity = none          # Proxy endpoints
+# dotnet_diagnostic.ASPIREPUBLISHERS001.severity = none              # Publishers feature
+# dotnet_diagnostic.ASPIREUSERSECRETS001.severity = none             # User secrets types
+##########################################
+
+##########################################
+# Custom - Code Analyzers Rules
+##########################################

--- a/sample/src/Demo.AppHost/Demo.AppHost.csproj
+++ b/sample/src/Demo.AppHost/Demo.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.1.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.2.4">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/sample/src/Demo.Domain/Demo.Domain.csproj
+++ b/sample/src/Demo.Domain/Demo.Domain.csproj
@@ -5,16 +5,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Asp.Versioning.Http" Version="8.1.1" />
+    <PackageReference Include="Asp.Versioning.Http" Version="10.0.0" />
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
-    <PackageReference Include="Atc" Version="3.0.16" />
+    <PackageReference Include="Atc" Version="3.0.67" />
     <PackageReference Include="Atc.Cosmos" Version="1.1.46" />
     <PackageReference Include="Bogus" Version="35.6.5" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageReference Include="Mapster" Version="7.4.0" />
+    <PackageReference Include="Mapster" Version="10.0.7" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/src/Demo.Domain/Extensions/ApplicationBuilderExtensions.cs
+++ b/sample/src/Demo.Domain/Extensions/ApplicationBuilderExtensions.cs
@@ -2,7 +2,8 @@ namespace Demo.Domain.Extensions;
 
 public static class ApplicationBuilderExtensions
 {
-    public static IApplicationBuilder InitializeDatabase(this IApplicationBuilder app)
+    public static IApplicationBuilder InitializeDatabase(
+        this IApplicationBuilder app)
     {
         using var serviceScope = app.ApplicationServices.CreateScope();
         var context = serviceScope.ServiceProvider.GetRequiredService<DemoDbContext>();

--- a/sample/src/Demo.Domain/Extensions/ServiceCollectionExtensions.cs
+++ b/sample/src/Demo.Domain/Extensions/ServiceCollectionExtensions.cs
@@ -15,7 +15,8 @@ public static class ServiceCollectionExtensions
         return services;
     }
 
-    public static void DefineHandlersAndServices(this IServiceCollection services)
+    public static void DefineHandlersAndServices(
+        this IServiceCollection services)
     {
         services.AddScoped<IGetUsersHandler, GetUsersHandler>();
         services.AddScoped<ICreateUserHandler, CreateUserHandler>();

--- a/sample/src/Demo.Domain/Storage/DemoDbContext.cs
+++ b/sample/src/Demo.Domain/Storage/DemoDbContext.cs
@@ -2,16 +2,14 @@ namespace Demo.Domain.Storage;
 
 public class DemoDbContext : DbContext
 {
-    public DemoDbContext(
-        DbContextOptions<DemoDbContext> options)
+    public DemoDbContext(DbContextOptions<DemoDbContext> options)
         : base(options)
     {
     }
 
     public virtual DbSet<UserEntity> Users { get; set; } = null!;
 
-    protected override void OnModelCreating(
-        ModelBuilder modelBuilder)
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<UserEntity>(entity =>
         {

--- a/sample/src/Demo.Domain/Users/Handlers/DeleteUserByIdHandler.cs
+++ b/sample/src/Demo.Domain/Users/Handlers/DeleteUserByIdHandler.cs
@@ -4,8 +4,7 @@ public sealed class DeleteUserByIdHandler : IDeleteUserByIdHandler
 {
     private readonly DemoDbContext dbContext;
 
-    public DeleteUserByIdHandler(
-        DemoDbContext dbContext)
+    public DeleteUserByIdHandler(DemoDbContext dbContext)
     {
         this.dbContext = dbContext;
     }

--- a/sample/src/Demo.Domain/Users/Handlers/GetUserByEmailHandler.cs
+++ b/sample/src/Demo.Domain/Users/Handlers/GetUserByEmailHandler.cs
@@ -4,8 +4,7 @@ public sealed class GetUserByEmailHandler : IGetUserByEmailHandler
 {
     private readonly DemoDbContext dbContext;
 
-    public GetUserByEmailHandler(
-        DemoDbContext dbContext)
+    public GetUserByEmailHandler(DemoDbContext dbContext)
     {
         this.dbContext = dbContext;
     }

--- a/sample/src/Demo.Domain/Users/Handlers/GetUserByIdHandler.cs
+++ b/sample/src/Demo.Domain/Users/Handlers/GetUserByIdHandler.cs
@@ -4,8 +4,7 @@ public sealed class GetUserByIdHandler : IGetUserByIdHandler
 {
     private readonly DemoDbContext dbContext;
 
-    public GetUserByIdHandler(
-        DemoDbContext dbContext)
+    public GetUserByIdHandler(DemoDbContext dbContext)
     {
         this.dbContext = dbContext;
     }

--- a/sample/src/Demo.Domain/Users/Handlers/GetUsersHandler.cs
+++ b/sample/src/Demo.Domain/Users/Handlers/GetUsersHandler.cs
@@ -4,8 +4,7 @@ public sealed class GetUsersHandler : IGetUsersHandler
 {
     private readonly DemoDbContext dbContext;
 
-    public GetUsersHandler(
-        DemoDbContext dbContext)
+    public GetUsersHandler(DemoDbContext dbContext)
     {
         this.dbContext = dbContext;
     }

--- a/sample/src/Demo.Domain/Users/Handlers/UpdateUserByIdHandler.cs
+++ b/sample/src/Demo.Domain/Users/Handlers/UpdateUserByIdHandler.cs
@@ -4,8 +4,7 @@ public sealed class UpdateUserByIdHandler : IUpdateUserByIdHandler
 {
     private readonly DemoDbContext dbContext;
 
-    public UpdateUserByIdHandler(
-        DemoDbContext dbContext)
+    public UpdateUserByIdHandler(DemoDbContext dbContext)
     {
         this.dbContext = dbContext;
     }

--- a/sample/src/Demo.Web/Demo.Web.csproj
+++ b/sample/src/Demo.Web/Demo.Web.csproj
@@ -5,15 +5,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc" Version="3.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
-    <PackageReference Include="MudBlazor" Version="8.15.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageReference Include="Atc" Version="3.0.67" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
+    <PackageReference Include="MudBlazor" Version="9.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>

--- a/sample/src/Demo.Web/Services/IUserService.cs
+++ b/sample/src/Demo.Web/Services/IUserService.cs
@@ -2,9 +2,12 @@ namespace Demo.Web.Services;
 
 public interface IUserService
 {
-    Task<IEnumerable<User>> GetAllUsersAsync(CancellationToken cancellationToken = default);
+    Task<IEnumerable<User>> GetAllUsersAsync(
+        CancellationToken cancellationToken = default);
 
-    Task<User?> GetUserByIdAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task<User?> GetUserByIdAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
 
     Task<(bool Success, ApiValidationProblemDetails? Errors)> CreateUserAsync(
         CreateUserRequest request,
@@ -15,5 +18,7 @@ public interface IUserService
         UpdateUserRequest request,
         CancellationToken cancellationToken = default);
 
-    Task<bool> DeleteUserAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task<bool> DeleteUserAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
 }

--- a/sample/src/Demo.Web/Services/UserService.cs
+++ b/sample/src/Demo.Web/Services/UserService.cs
@@ -16,7 +16,8 @@ public class UserService : IUserService
         this.logger = logger;
     }
 
-    public async Task<IEnumerable<User>> GetAllUsersAsync(CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<User>> GetAllUsersAsync(
+        CancellationToken cancellationToken = default)
     {
         try
         {
@@ -34,7 +35,9 @@ public class UserService : IUserService
         }
     }
 
-    public async Task<User?> GetUserByIdAsync(Guid userId, CancellationToken cancellationToken = default)
+    public async Task<User?> GetUserByIdAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default)
     {
         try
         {

--- a/sample/test/Demo.Api.Contracts.Tests/Demo.Api.Contracts.Tests.csproj
+++ b/sample/test/Demo.Api.Contracts.Tests/Demo.Api.Contracts.Tests.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\..\src\Demo.Api\Demo.Api.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+  </ItemGroup>
+
 </Project>

--- a/sample/test/Demo.Api.IntegrationTests/Demo.Api.IntegrationTests.csproj
+++ b/sample/test/Demo.Api.IntegrationTests/Demo.Api.IntegrationTests.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\..\src\Demo.Api\Demo.Api.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+  </ItemGroup>
+
 </Project>

--- a/sample/test/Demo.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
+++ b/sample/test/Demo.Api.IntegrationTests/Infrastructure/TestWebApplicationFactory.cs
@@ -3,8 +3,7 @@ namespace Demo.Api.IntegrationTests.Infrastructure;
 public class TestWebApplicationFactory<TProgram> : WebApplicationFactory<TProgram>
     where TProgram : class
 {
-    protected override IHost CreateHost(
-        IHostBuilder builder)
+    protected override IHost CreateHost(IHostBuilder builder)
     {
         builder.ConfigureServices(services =>
         {

--- a/sample/test/Demo.Domain.Tests/Demo.Domain.Tests.csproj
+++ b/sample/test/Demo.Domain.Tests/Demo.Domain.Tests.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\..\src\Demo.Domain\Demo.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+  </ItemGroup>
+
 </Project>

--- a/sample/test/Demo.Domain.Tests/Infrastructure/HandlerTestBase.cs
+++ b/sample/test/Demo.Domain.Tests/Infrastructure/HandlerTestBase.cs
@@ -17,8 +17,7 @@ public abstract class HandlerTestBase : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    protected virtual void Dispose(
-        bool disposing)
+    protected virtual void Dispose(bool disposing)
     {
         if (disposing)
         {

--- a/sample/test/Directory.Build.props
+++ b/sample/test/Directory.Build.props
@@ -18,14 +18,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
-    <PackageReference Include="Atc.Rest.FluentAssertions" Version="3.0.16" />
-    <PackageReference Include="Atc.Test" Version="2.0.16" />
+    <PackageReference Include="Atc.Rest.FluentAssertions" Version="3.0.67" />
+    <PackageReference Include="Atc.Test" Version="2.0.17" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageReference Include="NSubstituteEquivalency" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.0.2" />
-    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.1" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.0
-# Updated: 03-06-2024
+# Version: 1.0.1
+# Updated: 20-04-2026
 # Location: src
 # Distribution: DotNet10
 # Inspired by: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
@@ -14,10 +14,6 @@
 # http://www.asyncfixer.com
 
 
-# Asyncify
-# https://github.com/hvanbakel/Asyncify-CSharp
-
-
 # Meziantou
 # https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
 
@@ -28,10 +24,6 @@
 
 # Microsoft - Compiler Errors
 # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/
-
-
-# SecurityCodeScan
-# https://security-code-scan.github.io/
 
 
 # StyleCop

--- a/src/Atc.Rest.MinimalApi/Atc.Rest.MinimalApi.csproj
+++ b/src/Atc.Rest.MinimalApi/Atc.Rest.MinimalApi.csproj
@@ -13,12 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Asp.Versioning.Http" Version="8.1.1" />
-    <PackageReference Include="Atc" Version="3.0.16" />
+    <PackageReference Include="Asp.Versioning.Http" Version="10.0.0" />
+    <PackageReference Include="Atc" Version="3.0.67" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="MiniValidation" Version="0.9.2" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.11.10" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.14.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atc.Rest.MinimalApi/Filters/Endpoints/ValidationFilter.cs
+++ b/src/Atc.Rest.MinimalApi/Filters/Endpoints/ValidationFilter.cs
@@ -95,7 +95,7 @@ public class ValidationFilter<T> : IEndpointFilter
         var result = new Dictionary<string, string[]>(StringComparer.Ordinal);
 
         // First, try to validate the main object (existing behavior)
-        var validator = context.HttpContext.RequestServices.GetService<IValidator<T>>();
+        var validator = context.HttpContext.RequestServices.GetService<FluentValidation.IValidator<T>>();
         if (validator is not null)
         {
             var validationResult = await validator.ValidateAsync(
@@ -135,16 +135,16 @@ public class ValidationFilter<T> : IEndpointFilter
             }
 
             var propertyType = property.PropertyType;
-            var validatorType = typeof(IValidator<>).MakeGenericType(propertyType);
+            var validatorType = typeof(FluentValidation.IValidator<>).MakeGenericType(propertyType);
 
             // Cast to non-generic IValidator interface
-            if (context.HttpContext.RequestServices.GetService(validatorType) is not IValidator validator)
+            if (context.HttpContext.RequestServices.GetService(validatorType) is not FluentValidation.IValidator validator)
             {
                 continue;
             }
 
             // Create ValidationContext dynamically
-            var contextType = typeof(ValidationContext<>).MakeGenericType(propertyType);
+            var contextType = typeof(FluentValidation.ValidationContext<>).MakeGenericType(propertyType);
             FluentValidation.IValidationContext? validationContext;
 
             try

--- a/src/Atc.Rest.MinimalApi/GlobalUsings.cs
+++ b/src/Atc.Rest.MinimalApi/GlobalUsings.cs
@@ -9,14 +9,11 @@ global using System.Text.Json;
 global using System.Text.Json.Nodes;
 global using System.Text.Json.Serialization;
 global using System.Text.RegularExpressions;
-
 global using Atc.Rest.MinimalApi.Abstractions;
 global using Atc.Rest.MinimalApi.Extensions;
 global using Atc.Rest.MinimalApi.Extensions.Internal;
 global using Atc.Rest.MinimalApi.Middleware;
 global using Atc.Rest.MinimalApi.Options;
-global using FluentValidation;
-
 global using Microsoft.AspNetCore.Builder;
 global using Microsoft.AspNetCore.Http;
 global using Microsoft.AspNetCore.Http.HttpResults;
@@ -26,5 +23,4 @@ global using Microsoft.AspNetCore.Mvc.ApiExplorer;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.OpenApi;
 global using MiniValidation;
-
 global using Swashbuckle.AspNetCore.SwaggerGen;

--- a/src/Atc.Rest.MinimalApi/Middleware/GlobalErrorHandlingMiddleware.cs
+++ b/src/Atc.Rest.MinimalApi/Middleware/GlobalErrorHandlingMiddleware.cs
@@ -28,6 +28,21 @@ public sealed partial class GlobalErrorHandlingMiddleware
     /// </summary>
     /// <param name="context">The <see cref="HttpContext"/> for the current request.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <remarks>
+    /// <see cref="OperationCanceledException"/> is treated specially:
+    /// <list type="bullet">
+    ///   <item>
+    ///     If <see cref="HttpContext.RequestAborted"/> has fired (the upstream client
+    ///     disconnected), the exception is silently swallowed because writing a response is
+    ///     pointless and may itself throw on the closed socket.
+    ///   </item>
+    ///   <item>
+    ///     Otherwise, the cancellation is treated as a server-side error (e.g. an inner
+    ///     <c>HttpClient.Timeout</c> fired) and is mapped via the configured exception
+    ///     resolver — by default to <c>504 Gateway Timeout</c>.
+    ///   </item>
+    /// </list>
+    /// </remarks>
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "OK.")]
     public async Task Invoke(HttpContext context)
     {
@@ -35,9 +50,10 @@ public sealed partial class GlobalErrorHandlingMiddleware
         {
             await next(context);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
         {
-            // Client disconnected or request was canceled - no error response needed
+            // Upstream client disconnected — writing a response is pointless and may throw
+            // because the socket is closed.
         }
         catch (Exception ex)
         {

--- a/src/Atc.Rest.MinimalApi/Options/ExceptionMappingResolver.cs
+++ b/src/Atc.Rest.MinimalApi/Options/ExceptionMappingResolver.cs
@@ -19,6 +19,7 @@ internal sealed class ExceptionMappingResolver
         [typeof(InvalidOperationException)] = HttpStatusCode.Conflict,
         [typeof(NotImplementedException)] = HttpStatusCode.NotImplemented,
         [typeof(TimeoutException)] = HttpStatusCode.GatewayTimeout,
+        [typeof(OperationCanceledException)] = HttpStatusCode.GatewayTimeout,
     }.ToFrozenDictionary();
 
     /// <summary>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -53,7 +53,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" PrivateAssets="All" />
   </ItemGroup>
 

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.0
-# Updated: 09-01-2025
+# Version: 1.0.1
+# Updated: 20-04-2026
 # Location: test
 # Distribution: DotNet10
 # Inspired by: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
@@ -14,37 +14,30 @@
 # http://www.asyncfixer.com
 
 
-# Asyncify
-# https://github.com/hvanbakel/Asyncify-CSharp
-
-
 # Meziantou
 # https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
-dotnet_diagnostic.MA0004.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0004.md
-dotnet_diagnostic.MA0016.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0016.md
+dotnet_diagnostic.MA0004.severity = none            # Use Task.ConfigureAwait(false)
+dotnet_diagnostic.MA0016.severity = none            # Prefer return collection abstraction over implementation
 dotnet_diagnostic.MA0051.severity = none            # Method Length
 
 
 # Microsoft - Code Analysis
 # https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/
-dotnet_diagnostic.CA1068.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1068.md
-dotnet_diagnostic.CA1602.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1602.md
-dotnet_diagnostic.CA1707.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1707.md
-dotnet_diagnostic.CA2007.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA2007.md
+dotnet_diagnostic.CA1068.severity = none            # CancellationToken parameters must come last
+dotnet_diagnostic.CA1602.severity = none
+dotnet_diagnostic.CA1707.severity = none            # Identifiers should not contain underscores
+dotnet_diagnostic.CA2007.severity = none            # Do not directly await a Task
+dotnet_diagnostic.CA2025.severity = none            # Ensure tasks using 'IDisposable' instances complete before the instances are disposed
 
 
 # Microsoft - Compiler Errors
 # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/
 
 
-# SecurityCodeScan
-# https://security-code-scan.github.io/
-
-
 # StyleCop
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers
-dotnet_diagnostic.SA1122.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1122.md
-dotnet_diagnostic.SA1133.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1133.md
+dotnet_diagnostic.SA1122.severity = none            # Use string.Empty for empty strings
+dotnet_diagnostic.SA1133.severity = none            # Do not combine attributes
 
 
 # SonarAnalyzer.CSharp

--- a/test/Atc.Rest.MinimalApi.Tests/Middleware/GlobalErrorHandlingMiddlewareTests.cs
+++ b/test/Atc.Rest.MinimalApi.Tests/Middleware/GlobalErrorHandlingMiddlewareTests.cs
@@ -218,6 +218,138 @@ public sealed class GlobalErrorHandlingMiddlewareTests
     }
 
     [Fact]
+    public async Task Invoke_WhenDownstreamTimeoutThrowsTaskCanceled_Returns504ProblemDetails()
+    {
+        // Arrange - RequestAborted is NOT triggered, simulating a downstream HttpClient.Timeout
+        var options = new GlobalErrorHandlingOptions
+        {
+            UseProblemDetailsAsResponseBody = true,
+        };
+
+        var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+
+        var middleware = new GlobalErrorHandlingMiddleware(
+            next: _ => throw new TaskCanceledException("Simulated downstream timeout"),
+            options: options);
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert
+        context.Response.StatusCode.Should().Be(StatusCodes.Status504GatewayTimeout);
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        var responseBody = await new StreamReader(context.Response.Body).ReadToEndAsync(TestContext.Current.CancellationToken);
+        responseBody.Should().NotBeEmpty();
+
+        using var doc = JsonDocument.Parse(responseBody);
+        doc.RootElement
+            .GetProperty("status")
+            .GetInt32()
+            .Should()
+            .Be(StatusCodes.Status504GatewayTimeout);
+    }
+
+    [Fact]
+    public async Task Invoke_WhenOperationCanceledThrown_Returns504ProblemDetails()
+    {
+        // Arrange - base type, verifies the resolver entry rather than just inheritance
+        var options = new GlobalErrorHandlingOptions
+        {
+            UseProblemDetailsAsResponseBody = true,
+        };
+
+        var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+
+        var middleware = new GlobalErrorHandlingMiddleware(
+            next: _ => throw new OperationCanceledException("Simulated handler-level deadline"),
+            options: options);
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert
+        context.Response.StatusCode.Should().Be(StatusCodes.Status504GatewayTimeout);
+    }
+
+    [Fact]
+    public async Task Invoke_WhenUpstreamClientDisconnectsDuringHandler_DoesNotWriteResponse()
+    {
+        // Arrange - RequestAborted IS triggered, upstream client genuinely disconnected
+        var options = new GlobalErrorHandlingOptions
+        {
+            UseProblemDetailsAsResponseBody = true,
+        };
+
+        using var aborted = new CancellationTokenSource();
+        await aborted.CancelAsync();
+
+        var context = new DefaultHttpContext
+        {
+            RequestAborted = aborted.Token,
+            Response = { Body = new MemoryStream() },
+        };
+
+        var middleware = new GlobalErrorHandlingMiddleware(
+            next: _ => throw new OperationCanceledException(aborted.Token),
+            options: options);
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert - silent: no body written and status code untouched
+        context.Response.Body.Length.Should().Be(0);
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Fact]
+    public async Task Invoke_WithCustomMappingForTaskCanceled_OverridesDefault()
+    {
+        // Arrange - consumers can opt out of 504 in favour of e.g. 408
+        var options = new GlobalErrorHandlingOptions
+        {
+            UseProblemDetailsAsResponseBody = false,
+        };
+
+        options.MapException<TaskCanceledException>(HttpStatusCode.RequestTimeout);
+
+        var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+
+        var middleware = new GlobalErrorHandlingMiddleware(
+            next: _ => throw new TaskCanceledException("Simulated downstream timeout"),
+            options: options);
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert
+        context.Response.StatusCode.Should().Be(StatusCodes.Status408RequestTimeout);
+    }
+
+    [Fact]
+    public async Task Invoke_WhenTimeoutExceptionThrown_Returns504ProblemDetails()
+    {
+        // Arrange - regression: ensure TimeoutException still maps to 504 alongside the new
+        // OperationCanceledException mapping.
+        var options = new GlobalErrorHandlingOptions
+        {
+            UseProblemDetailsAsResponseBody = true,
+        };
+
+        var context = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+
+        var middleware = new GlobalErrorHandlingMiddleware(
+            next: _ => throw new TimeoutException("Simulated timeout"),
+            options: options);
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert
+        context.Response.StatusCode.Should().Be(StatusCodes.Status504GatewayTimeout);
+    }
+
+    [Fact]
     public async Task Invoke_WithTeapotMapping_Returns418()
     {
         // Arrange - Demonstrate custom exception with 418 I'm a teapot (not in HttpStatusCode enum)

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -17,15 +17,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc.Rest.FluentAssertions" Version="3.0.16" />
-    <PackageReference Include="Atc.Test" Version="2.0.16" />
-    <PackageReference Include="Atc.XUnit" Version="3.0.16" />
+    <PackageReference Include="Atc.Rest.FluentAssertions" Version="3.0.67" />
+    <PackageReference Include="Atc.Test" Version="2.0.17" />
+    <PackageReference Include="Atc.XUnit" Version="3.0.67" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageReference Include="NSubstituteEquivalency" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.3.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.0.2" />
-    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.1" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
  # Summary

  - Stop returning silent 200 OK with empty body on downstream timeouts
  - Map non-disconnect OperationCanceledException to 504 Gateway Timeout
  - Refresh ATC coding rules and bump analyzer/runtime/test dependencies

  # Changes

  ### :bug: Fixes
  - Gate silent OperationCanceledException arm on RequestAborted token
  - Restore real error response on HttpClient.Timeout and CancelAfter
  - Cover TaskCanceledException via existing resolver inheritance walk

  ### :sparkles: Features
  - Add OperationCanceledException to default exception->status mappings
  - Default mapping resolves to HTTP 504 Gateway Timeout
  - Override per consumer via options.MapException<T>(...) as before

  ### :package: Dependencies
  - Bump Atc 3.0.16 -> 3.0.67 across sample apps and test packages
  - Bump Asp.Versioning.* 8.1 -> 10.0, Mapster 7.4 -> 10.0
  - Bump EF Core InMemory 10.0.1 -> 10.0.7, MudBlazor 8.15 -> 9.4
  - Bump OpenTelemetry.* 1.14 -> 1.15, Aspire.AppHost.Sdk 13.1 -> 13.2.4
  - Bump Mvc.Testing 10.0.1 -> 10.0.7, NET.Test.Sdk 18.0.1 -> 18.5.1
  - Bump xunit.v3.mtp-v2 3.2.1 -> 3.2.2, Atc.Test 2.0.16 -> 2.0.17

  ### :wrench: Configuration
  - Update ATC coding rules to v1.0.1 in root, src, and test editorconfigs
  - Add v1.1.0 editorconfig for the new sample/Demo.AppHost project
  - Drop Asyncify and SecurityCodeScan.VS2019 from analyzer set
  - Bump Atc.Analyzer 0.1.17 -> 0.1.23, Meziantou 2.0.267 -> 3.0.58
  - Bump SonarAnalyzer.CSharp 10.17 -> 10.25

  ### :art: Styling
  - Reformat sample sources to match new analyzer rules
  - Reorganize GlobalUsings to absorb a Program.cs local using

  ### :memo: Documentation
  - Expand XML doc on Invoke to describe the cancellation split

  # Notes

  - Behaviour change for consumers relying on the silent-200 path; treat
    as a minor bump in release notes
  - True upstream client disconnect (RequestAborted fired) still returns
    silently with no body written
  - Telemetry on the swallowed-disconnect arm is intentionally deferred
    to a follow-up PR
