### PR TITLE
chore(deps): update packages and bump Aspire AppHost SDK to 13.4.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,9 +47,9 @@
   <ItemGroup Label="Code Analyzers">
     <PackageReference Include="Atc.Analyzer" Version="0.1.23" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.58" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.117" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.25.0.139117" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/aspire.config.json
+++ b/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "sample/src/Demo.AppHost/Demo.AppHost.csproj"
+  }
+}

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="https://api.nuget.org/v3/index.json" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="https://api.nuget.org/v3/index.json">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/sample/.editorconfig
+++ b/sample/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.9
-# Updated: 24-11-2022
+# Version: 1.0.10
+# Updated: 03-06-2024
 # Location: Root
 # Distribution: DotNet7
 # Inspired by: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
@@ -201,8 +201,8 @@ csharp_style_unused_value_assignment_preference = discard_variable              
 
 # Index and range preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#index-and-range-preferences
-csharp_style_prefer_index_operator = true                                       # IDE0056
-csharp_style_prefer_range_operator = true                                       # IDE0057
+csharp_style_prefer_index_operator = true:suggestion                            # IDE0056
+csharp_style_prefer_range_operator = true:suggestion                            # IDE0057
 
 # Miscellaneous preferences
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-language-conventions#miscellaneous-preferences
@@ -447,29 +447,44 @@ dotnet_naming_rule.parameters_rule.severity             = warning
 
 # Meziantou
 # https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
-dotnet_diagnostic.MA0003.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0003.md
-dotnet_diagnostic.MA0004.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0004.md
-dotnet_diagnostic.MA0006.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0006.md
-dotnet_diagnostic.MA0016.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0016.md
-dotnet_diagnostic.MA0025.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0025.md
-dotnet_diagnostic.MA0026.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0026.md
-dotnet_diagnostic.MA0028.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0028.md
-dotnet_diagnostic.MA0048.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0048.md
+dotnet_diagnostic.MA0003.severity = suggestion      # Add argument name to improve readability
+dotnet_diagnostic.MA0004.severity = suggestion      # Use Task.ConfigureAwait(false)
+dotnet_diagnostic.MA0006.severity = none            # Use String.Equals instead of equality operator
+dotnet_diagnostic.MA0011.severity = none            # Duplicate of CA1305
+dotnet_diagnostic.MA0016.severity = error           # Prefer return collection abstraction over implementation
+dotnet_diagnostic.MA0025.severity = suggestion      # Implement functionality instead of throwing NotImplementedException
+dotnet_diagnostic.MA0026.severity = suggestion      # Fix TODO comment
+dotnet_diagnostic.MA0028.severity = none            # Optimize StringBuilder usage
+dotnet_diagnostic.MA0038.severity = none            # Duplicate of CA1822
+dotnet_diagnostic.MA0048.severity = error           # File name must match type name
 
 
 # Microsoft - Code Analysis
 # https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/
-dotnet_diagnostic.CA1014.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1014.md
-dotnet_diagnostic.CA1068.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1068.md
-dotnet_diagnostic.CA1707.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1707.md
-dotnet_diagnostic.CA2007.severity = suggestion      # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA2007.md
-dotnet_diagnostic.IDE0005.severity = warning        # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/IDE0005.md
-dotnet_diagnostic.IDE0058.severity = none           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/IDE0058.md
+dotnet_diagnostic.CA1014.severity = none            # Mark assemblies with CLSCompliantAttribute
+dotnet_diagnostic.CA1068.severity = error           # CancellationToken parameters must come last
+dotnet_diagnostic.CA1305.severity = error
+dotnet_diagnostic.CA1308.severity = suggestion      # Normalize strings to uppercase
+dotnet_diagnostic.CA1707.severity = error           # Identifiers should not contain underscores
+dotnet_diagnostic.CA1812.severity = none
+dotnet_diagnostic.CA1822.severity = suggestion
+dotnet_diagnostic.CA1849.severity = error           # Call async methods when in an async method
+dotnet_diagnostic.CA2007.severity = suggestion      # Do not directly await a Task
+dotnet_diagnostic.CA2017.severity = error           # Parameter count mismatch
+dotnet_diagnostic.CA2018.severity = error           # The count argument to Buffer.BlockCopy should specify the number of bytes to copy
+dotnet_diagnostic.CA2019.severity = error           # ThreadStatic fields should not use inline initialization
+dotnet_diagnostic.CA2250.severity = suggestion      # Use ThrowIfCancellationRequested
+dotnet_diagnostic.CA2252.severity = suggestion      # Opt-in to preview features should be used with caution
+dotnet_diagnostic.CA2253.severity = error           # Named placeholders should not be numeric values
+dotnet_diagnostic.CA2254.severity = suggestion      # Template should be a static expression
+dotnet_diagnostic.CA2255.severity = suggestion      # The ModuleInitializer attribute should not be used in libraries
+dotnet_diagnostic.IDE0005.severity = warning        # Remove unnecessary using directives
+dotnet_diagnostic.IDE0058.severity = none           # Remove unnecessary expression value
 
 
 # Microsoft - Compiler Errors
 # https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/
-dotnet_diagnostic.CS4014.severity = error          # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCompilerErrors/CS4014.md
+dotnet_diagnostic.CS4014.severity = error           # Call is not awaited
 
 
 # SecurityCodeScan
@@ -478,27 +493,28 @@ dotnet_diagnostic.CS4014.severity = error          # https://github.com/atc-net/
 
 # StyleCop
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers
-dotnet_diagnostic.SA1009.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1009.md
-dotnet_diagnostic.SA1101.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1101.md
-dotnet_diagnostic.SA1122.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1122.md
-dotnet_diagnostic.SA1133.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1133.md
-dotnet_diagnostic.SA1200.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1200.md
-dotnet_diagnostic.SA1201.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1201.md
-dotnet_diagnostic.SA1202.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1202.md
-dotnet_diagnostic.SA1204.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1204.md
-dotnet_diagnostic.SA1413.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1413.md
-dotnet_diagnostic.SA1600.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1600.md
-dotnet_diagnostic.SA1602.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1602.md
-dotnet_diagnostic.SA1604.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1604.md
-dotnet_diagnostic.SA1623.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1623.md
-dotnet_diagnostic.SA1629.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1629.md
-dotnet_diagnostic.SA1633.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1633.md
-dotnet_diagnostic.SA1649.severity = error           # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1649.md
+dotnet_diagnostic.SA1009.severity = none            # Closing parenthesis should be spaced correctly
+dotnet_diagnostic.SA1101.severity = none            # Prefix local calls with this
+dotnet_diagnostic.SA1122.severity = error           # Use string.Empty for empty strings
+dotnet_diagnostic.SA1133.severity = error           # Do not combine attributes
+dotnet_diagnostic.SA1200.severity = none            # Using directives should be placed correctly
+dotnet_diagnostic.SA1201.severity = none            # Elements should appear in the correct order
+dotnet_diagnostic.SA1202.severity = none            # Elements should be ordered by access
+dotnet_diagnostic.SA1204.severity = none            # Static elements should appear before instance elements
+dotnet_diagnostic.SA1413.severity = error           # Use trailing commas in multi-line initializers
+dotnet_diagnostic.SA1600.severity = none            # Elements should be documented
+dotnet_diagnostic.SA1601.severity = none
+dotnet_diagnostic.SA1602.severity = none            # Enumeration items should be documented
+dotnet_diagnostic.SA1604.severity = none            # Element documentation should have summary
+dotnet_diagnostic.SA1623.severity = none            # Property summary documentation should match accessors
+dotnet_diagnostic.SA1629.severity = none            # Documentation text should end with a period
+dotnet_diagnostic.SA1633.severity = none            # File should have header
+dotnet_diagnostic.SA1649.severity = error           # File name should match first type name
 
 
 # SonarAnalyzer.CSharp
 # https://rules.sonarsource.com/csharp
-dotnet_diagnostic.S1135.severity = suggestion       # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/SonarAnalyzerCSharp/S1135.md
+dotnet_diagnostic.S1135.severity = suggestion       # Track uses of TODO tags
 
 
 ##########################################

--- a/sample/Directory.Build.props
+++ b/sample/Directory.Build.props
@@ -47,9 +47,9 @@
   <ItemGroup Label="Code Analyzers">
     <PackageReference Include="Atc.Analyzer" Version="0.1.23" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.58" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.117" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.25.0.139117" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/sample/src/Demo.Api.Contracts/Demo.Api.Contracts.csproj
+++ b/sample/src/Demo.Api.Contracts/Demo.Api.Contracts.csproj
@@ -6,9 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Http" Version="10.0.0" />
-    <PackageReference Include="Atc" Version="3.0.67" />
+    <PackageReference Include="Atc" Version="3.0.174" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
   </ItemGroup>
 

--- a/sample/src/Demo.Api/Demo.Api.csproj
+++ b/sample/src/Demo.Api/Demo.Api.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc" Version="3.0.67" />
+    <PackageReference Include="Atc" Version="3.0.174" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.14.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/src/Demo.AppHost/.editorconfig
+++ b/sample/src/Demo.AppHost/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.1.0
-# Updated: 24-04-2026
+# Version: 1.3.0
+# Updated: 07-06-2026
 # Location: aspire
 # Distribution: Frameworks
 
@@ -35,10 +35,10 @@ dotnet_diagnostic.S6964.severity = none             # Value type property valida
 #
 # Experimental API Warnings (suppress if using these features):
 # dotnet_diagnostic.ASPIREACADOMAINS001.severity = none              # Azure Container Apps custom domains
-# dotnet_diagnostic.ASPIREATS001.severity = none                     # Aspire Type Specification (ATS) types
 # dotnet_diagnostic.ASPIREAZURE001.severity = none                   # Azure publishers
 # dotnet_diagnostic.ASPIREAZURE002.severity = none                   # Azure Container App Jobs
 # dotnet_diagnostic.ASPIREAZURE003.severity = none                   # Azure Virtual Network types
+# dotnet_diagnostic.ASPIREBROWSERLOGS001.severity = none             # Browser logs (WithBrowserLogs, Aspire.Hosting.Browsers) (13.4)
 # dotnet_diagnostic.ASPIRECERTIFICATES001.severity = none            # Certificate configuration types
 # dotnet_diagnostic.ASPIRECOMPUTE001.severity = none                 # Custom compute environments
 # dotnet_diagnostic.ASPIRECOMPUTE002.severity = none                 # GetHostAddressExpression method
@@ -64,16 +64,19 @@ dotnet_diagnostic.S6964.severity = none             # Value type property valida
 # dotnet_diagnostic.ASPIREHOSTINGPYTHON001.severity = none           # Python app orchestration
 # dotnet_diagnostic.ASPIREINTERACTION001.severity = none             # Interaction service types
 # dotnet_diagnostic.ASPIREMCP001.severity = none                     # MCP server types
+# dotnet_diagnostic.ASPIREPERSISTENCE001.severity = none             # Shared resource lifetime APIs (13.4)
 # dotnet_diagnostic.ASPIREPIPELINES001.severity = none               # Deployment pipeline infrastructure
 # dotnet_diagnostic.ASPIREPIPELINES002.severity = none               # Deployment state manager
 # dotnet_diagnostic.ASPIREPIPELINES003.severity = none               # Container image build
 # dotnet_diagnostic.ASPIREPIPELINES004.severity = none               # Pipeline types under evaluation
 # dotnet_diagnostic.ASPIREPOSTGRES001.severity = none                # PostgreSQL MCP integration
 # dotnet_diagnostic.ASPIREPROBES001.severity = none                  # Probe-related types
+# dotnet_diagnostic.ASPIREPROCESSCOMMAND001.severity = none          # Process-backed resource commands (13.4)
 # dotnet_diagnostic.ASPIREPROXYENDPOINTS001.severity = none          # Proxy endpoints
 # dotnet_diagnostic.ASPIREPUBLISHERS001.severity = none              # Publishers feature
 # dotnet_diagnostic.ASPIREUSERSECRETS001.severity = none             # User secrets types
 ##########################################
+
 
 ##########################################
 # Custom - Code Analyzers Rules

--- a/sample/src/Demo.AppHost/Demo.AppHost.csproj
+++ b/sample/src/Demo.AppHost/Demo.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.4">
+<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/sample/src/Demo.Domain/Demo.Domain.csproj
+++ b/sample/src/Demo.Domain/Demo.Domain.csproj
@@ -7,14 +7,14 @@
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Http" Version="10.0.0" />
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
-    <PackageReference Include="Atc" Version="3.0.67" />
+    <PackageReference Include="Atc" Version="3.0.174" />
     <PackageReference Include="Atc.Cosmos" Version="1.1.46" />
     <PackageReference Include="Bogus" Version="35.6.5" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageReference Include="Mapster" Version="10.0.7" />
+    <PackageReference Include="Mapster" Version="10.0.10" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/src/Demo.Web/Demo.Web.csproj
+++ b/sample/src/Demo.Web/Demo.Web.csproj
@@ -5,14 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc" Version="3.0.67" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
-    <PackageReference Include="MudBlazor" Version="9.4.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="Atc" Version="3.0.174" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+    <PackageReference Include="MudBlazor" Version="9.6.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 

--- a/sample/test/.editorconfig
+++ b/sample/test/.editorconfig
@@ -20,15 +20,16 @@
 
 # Meziantou
 # https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
-dotnet_diagnostic.MA0004.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0004.md
-dotnet_diagnostic.MA0016.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0016.md
+dotnet_diagnostic.MA0004.severity = none            # Use Task.ConfigureAwait(false)
+dotnet_diagnostic.MA0016.severity = none            # Prefer return collection abstraction over implementation
 
 
 # Microsoft - Code Analysis
 # https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/
-dotnet_diagnostic.CA1068.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1068.md
-dotnet_diagnostic.CA1707.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA1707.md
-dotnet_diagnostic.CA2007.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/MicrosoftCodeAnalysis/CA2007.md
+dotnet_diagnostic.CA1068.severity = none            # CancellationToken parameters must come last
+dotnet_diagnostic.CA1602.severity = none
+dotnet_diagnostic.CA1707.severity = none            # Identifiers should not contain underscores
+dotnet_diagnostic.CA2007.severity = none            # Do not directly await a Task
 
 
 # Microsoft - Compiler Errors
@@ -41,8 +42,8 @@ dotnet_diagnostic.CA2007.severity = none            # https://github.com/atc-net
 
 # StyleCop
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers
-dotnet_diagnostic.SA1122.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1122.md
-dotnet_diagnostic.SA1133.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/StyleCop/SA1133.md
+dotnet_diagnostic.SA1122.severity = none            # Use string.Empty for empty strings
+dotnet_diagnostic.SA1133.severity = none            # Do not combine attributes
 
 
 # SonarAnalyzer.CSharp

--- a/sample/test/Demo.Api.Contracts.Tests/Demo.Api.Contracts.Tests.csproj
+++ b/sample/test/Demo.Api.Contracts.Tests/Demo.Api.Contracts.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/sample/test/Demo.Api.IntegrationTests/Demo.Api.IntegrationTests.csproj
+++ b/sample/test/Demo.Api.IntegrationTests/Demo.Api.IntegrationTests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/sample/test/Demo.Domain.Tests/Demo.Domain.Tests.csproj
+++ b/sample/test/Demo.Domain.Tests/Demo.Domain.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/sample/test/Directory.Build.props
+++ b/sample/test/Directory.Build.props
@@ -17,14 +17,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
-    <PackageReference Include="Atc.Rest.FluentAssertions" Version="3.0.67" />
-    <PackageReference Include="Atc.Test" Version="2.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Atc.Rest.AwesomeAssertions" Version="3.0.174" />
+    <PackageReference Include="Atc.Test" Version="3.0.0" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageReference Include="NSubstituteEquivalency" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.3" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
@@ -36,7 +36,7 @@
     <Using Include="Atc.Test" />
     <Using Include="AutoFixture" />
     <Using Include="AutoFixture.Xunit3" />
-    <Using Include="FluentAssertions" />
+    <Using Include="AwesomeAssertions" />
     <Using Include="NSubstitute" />
     <Using Include="Xunit" />
   </ItemGroup>

--- a/src/Atc.Rest.MinimalApi/Atc.Rest.MinimalApi.csproj
+++ b/src/Atc.Rest.MinimalApi/Atc.Rest.MinimalApi.csproj
@@ -14,11 +14,11 @@
 
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Http" Version="10.0.0" />
-    <PackageReference Include="Atc" Version="3.0.67" />
+    <PackageReference Include="Atc" Version="3.0.174" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageReference Include="MiniValidation" Version="0.9.2" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.14.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
+    <PackageReference Include="MiniValidation" Version="0.10.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.16.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -53,8 +53,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.10.85" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -17,14 +17,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc.Rest.FluentAssertions" Version="3.0.67" />
-    <PackageReference Include="Atc.Test" Version="2.0.17" />
-    <PackageReference Include="Atc.XUnit" Version="3.0.67" />
+    <PackageReference Include="Atc.Rest.AwesomeAssertions" Version="3.0.174" />
+    <PackageReference Include="Atc.Test" Version="3.0.0" />
+    <PackageReference Include="Atc.XUnit" Version="3.0.174" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageReference Include="NSubstituteEquivalency" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.8.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.3" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
@@ -36,7 +36,7 @@
     <Using Include="Atc.Test" />
     <Using Include="AutoFixture" />
     <Using Include="AutoFixture.Xunit3" />
-    <Using Include="FluentAssertions" />
+    <Using Include="AwesomeAssertions" />
     <Using Include="NSubstitute" />
     <Using Include="Xunit" />
   </ItemGroup>


### PR DESCRIPTION
- Bump Aspire.AppHost.Sdk 13.2.4 -> 13.4.6 and refresh Aspire experimental-API entries in Demo.AppHost/.editorconfig
- Add nuget.config (nuget.org source + package source mapping) and aspire.config.json (AppHost path for the Aspire CLI)
- Update Atc, Scalar.AspNetCore, Swashbuckle.AspNetCore, MudBlazor, OpenTelemetry, Mapster, EF Core InMemory, and other package versions across src/sample/test projects
- Replace FluentAssertions with AwesomeAssertions in test projects (Atc.Rest.FluentAssertions -> Atc.Rest.AwesomeAssertions, Atc.Test 2.0.17 -> 3.0.0)
- Refresh ATC coding-rules editorconfig comments/analyzer rules (Meziantou, SonarAnalyzer, StyleCop, CA rule additions)